### PR TITLE
Sanitize admin user listings

### DIFF
--- a/backend/src/routes/admin.routes.ts
+++ b/backend/src/routes/admin.routes.ts
@@ -1,12 +1,12 @@
 import { Router } from "express";
 import { authRequired, adminOnly } from "../middleware/auth.middleware";
-import { getAllUsers } from "../services/auth.service";
+import { getPublicUsers } from "../services/auth.service";
 import { getDemoModerationEvents } from "../ia/moderation.service";
 
 const router=Router();
 
 router.get("/dashboard", authRequired, adminOnly,(req,res)=>res.json({admin:true}));
-router.get("/users", authRequired, adminOnly,(req,res)=>res.json({users:getAllUsers()}));
+router.get("/users", authRequired, adminOnly,(req,res)=>res.json({users:getPublicUsers()}));
 router.get("/ai/activity", authRequired, adminOnly,(req,res)=>res.json({events:getDemoModerationEvents()}));
 
 export default router;

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -65,4 +65,16 @@ function createAuthTokenResponse(user: User): AuthTokenResponse {
   return { token, user: { id: user.id, name: user.name, email: user.email, role: user.role }};
 }
 
-export function getAllUsers(): User[] { return users; }
+export function getAllUsers(): User[] {
+  return users;
+}
+
+export function getPublicUsers(): Array<Omit<User, "passwordHash">> {
+  return users.map(({ id, name, email, role, createdAt }) => ({
+    id,
+    name,
+    email,
+    role,
+    createdAt
+  }));
+}


### PR DESCRIPTION
## Summary
- add a helper to return public user details without sensitive fields
- update the admin users route to use the sanitized payload

## Testing
- node -e "require('ts-node/register/transpile-only'); const { getPublicUsers } = require('./src/services/auth.service'); console.log(getPublicUsers());"

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ca4728b988326afe46b16be705746)