### PR TITLE
Document seeded admin credentials

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,5 @@
+# Backend
+
+## Auth seeding
+- The service seeds an admin demo user for development and testing: `admin@newmersive.local` with password `admin123`.
+- Credentials live only in the in-memory user list; nothing is persisted to disk or a database, and no password hashes are exposed.

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -6,7 +6,8 @@ import { AuthTokenResponse, User, UserRole } from "../shared/types";
 const users: User[] = [];
 let userIdCounter = 1;
 
-// Seed admin
+// Seed admin demo user for development (email: admin@newmersive.local, password: admin123).
+// The credentials are stored only in memory to avoid persisting secrets.
 (function seedAdmin() {
   const adminEmail = "admin@newmersive.local";
   const exists = users.find(u => u.email === adminEmail);


### PR DESCRIPTION
## Summary
- clarify the admin seed comment with the demo email, password, and in-memory storage note
- add backend README describing the seeded admin credentials to guide login testing

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ca47436648326a87ff694a1febb27)