### PR TITLE
Add auth endpoint tests with node test runner

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,19 @@
+# Newmersive Backend
+
+## Scripts
+
+- `npm run dev`: inicia el servidor en modo desarrollo con recarga automática.
+- `npm run build`: compila TypeScript a JavaScript en `dist/`.
+- `npm test`: ejecuta la suite con el runner nativo de Node (`node:test`) usando `ts-node` y `NODE_ENV=test`.
+
+## Pruebas
+
+Las pruebas viven en `tests/` y verifican:
+- Registro y login (`POST /auth/register` y `POST /auth/login`) devolviendo los códigos de estado esperados y un token JWT.
+- La protección de rutas administrativas a través de `authRequired` y `adminOnly`, rechazando tokens ausentes/erróneos y permitiendo sólo a usuarios con rol `admin`.
+
+Ejecuta todas las pruebas con:
+
+```bash
+npm test
+```

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only src/server.ts",
     "build": "tsc",
-    "start": "node dist/server.js"
+    "start": "node dist/server.js",
+    "test": "NODE_ENV=test node --test -r ts-node/register ./tests/**/*.ts"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,10 +1,16 @@
 import express from "express";
+// @ts-ignore - type definitions unavailable in offline environment
 import cors from "cors";
 import { ENV } from "./config/env";
 import apiRouter from "./routes";
 
-const app=express();
+export const app = express();
 app.use(cors());
 app.use(express.json());
-app.use("/api",apiRouter);
-app.listen(ENV.PORT,()=>console.log("API OK"));
+app.use("/api", apiRouter);
+
+if (ENV.NODE_ENV !== "test") {
+  app.listen(ENV.PORT, () => console.log("API OK"));
+}
+
+export default app;

--- a/backend/src/types.d.ts
+++ b/backend/src/types.d.ts
@@ -1,0 +1,1 @@
+declare module "cors";

--- a/backend/tests/auth.spec.ts
+++ b/backend/tests/auth.spec.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert";
+import { after, before, describe, it } from "node:test";
+import { AddressInfo } from "node:net";
+import { app } from "../src/server";
+
+let baseUrl: string;
+let server: ReturnType<typeof app.listen>;
+
+before(async () => {
+  server = app.listen(0);
+  await new Promise<void>(resolve => server.once("listening", resolve));
+  const address = server.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${address.port}/api`;
+});
+
+after(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close(err => (err ? reject(err) : resolve()));
+  });
+});
+
+async function post(path: string, body: Record<string, unknown>): Promise<{ status: number; body: any }> {
+  const response = await fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+
+  return { status: response.status, body: await response.json() };
+}
+
+describe("Auth routes", () => {
+  const email = `user+${Date.now()}@test.local`;
+  const password = "password123";
+
+  it("should register a new user and return a token", async () => {
+    const res = await post("/auth/register", { name: "Test User", email, password });
+
+    assert.equal(res.status, 201);
+    assert.equal(typeof res.body.token, "string");
+    assert.equal(res.body.user.email, email.toLowerCase());
+  });
+
+  it("should log in an existing user and return a token", async () => {
+    const res = await post("/auth/login", { email, password });
+
+    assert.equal(res.status, 200);
+    assert.equal(typeof res.body.token, "string");
+    assert.equal(res.body.user.email, email.toLowerCase());
+  });
+});
+
+describe("auth middleware", () => {
+  const memberEmail = `member+${Date.now()}@test.local`;
+  const memberPassword = "memberPass123";
+  let memberToken: string;
+  let adminToken: string;
+
+  before(async () => {
+    const registerRes = await post("/auth/register", { name: "Member", email: memberEmail, password: memberPassword });
+    memberToken = registerRes.body.token;
+
+    const adminLogin = await post("/auth/login", { email: "admin@newmersive.local", password: "admin123" });
+    adminToken = adminLogin.body.token;
+  });
+
+  it("should reject missing tokens", async () => {
+    const res = await fetch(`${baseUrl}/admin/dashboard`);
+    const body: any = await res.json();
+
+    assert.equal(res.status, 401);
+    assert.equal(body.error, "UNAUTHORIZED");
+  });
+
+  it("should reject invalid tokens", async () => {
+    const res = await fetch(`${baseUrl}/admin/dashboard`, {
+      headers: { Authorization: "Bearer invalid.token.here" }
+    });
+    const body: any = await res.json();
+
+    assert.equal(res.status, 401);
+    assert.equal(body.error, "INVALID_TOKEN");
+  });
+
+  it("should block non-admin users", async () => {
+    const res = await fetch(`${baseUrl}/admin/dashboard`, {
+      headers: { Authorization: `Bearer ${memberToken}` }
+    });
+    const body: any = await res.json();
+
+    assert.equal(res.status, 403);
+    assert.equal(body.error, "FORBIDDEN");
+  });
+
+  it("should allow admin users", async () => {
+    const res = await fetch(`${baseUrl}/admin/dashboard`, {
+      headers: { Authorization: `Bearer ${adminToken}` }
+    });
+    const body: any = await res.json();
+
+    assert.equal(res.status, 200);
+    assert.equal(body.admin, true);
+  });
+});


### PR DESCRIPTION
## Summary
- expose the Express app without binding during tests to support integration coverage
- add node:test suite covering auth register/login plus admin middleware scenarios
- document the new npm test command for running the suite

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ca47563dc8326a725eacd52b596ab)