### PR TITLE
Implement unified backend auth and persistence

### DIFF
--- a/allwain/src/config/api.ts
+++ b/allwain/src/config/api.ts
@@ -1,4 +1,5 @@
-export const API_BASE_URL = "http://localhost:4000/api";
+export const API_BASE_URL =
+  process.env.EXPO_PUBLIC_API_BASE_URL || "http://localhost:4000/api";
 
 export interface AuthResponse {
   token: string;

--- a/allwain/src/screens/Auth/AuthScreen.tsx
+++ b/allwain/src/screens/Auth/AuthScreen.tsx
@@ -12,6 +12,7 @@ import { useAuthStore } from "../../store/auth.store";
 import { colors } from "../../theme/colors";
 
 export default function AuthScreen() {
+  const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
@@ -21,8 +22,8 @@ export default function AuthScreen() {
   const register = useAuthStore((s) => s.register);
 
   async function handleAuth(action: "login" | "register") {
-    if (!email || !password) {
-      setError("Ingresa email y contraseña");
+    if (!email || !password || (action === "register" && !name)) {
+      setError("Completa nombre, email y contraseña");
       return;
     }
 
@@ -33,10 +34,10 @@ export default function AuthScreen() {
       if (action === "login") {
         await login(email, password);
       } else {
-        await register(email, password);
+        await register(name, email, password);
       }
-    } catch (err) {
-      setError("No se pudo procesar la solicitud (mock)");
+    } catch (err: any) {
+      setError(err?.message || "No se pudo procesar la solicitud");
     } finally {
       setLoading(false);
     }
@@ -51,6 +52,15 @@ export default function AuthScreen() {
         </View>
 
         <View style={styles.form}>
+          <Text style={styles.label}>Nombre</Text>
+          <TextInput
+            style={styles.input}
+            placeholder="Tu nombre"
+            placeholderTextColor={colors.muted}
+            value={name}
+            onChangeText={setName}
+          />
+
           <Text style={styles.label}>Email</Text>
           <TextInput
             style={styles.input}

--- a/allwain/src/screens/Auth/LoginScreen.tsx
+++ b/allwain/src/screens/Auth/LoginScreen.tsx
@@ -3,11 +3,10 @@ import {
   View,
   Text,
   TextInput,
-  Button,
+  TouchableOpacity,
   StyleSheet,
   ActivityIndicator,
 } from "react-native";
-import { apiPost, AuthResponse } from "../../config/api";
 import { useAuthStore } from "../../store/auth.store";
 import { colors } from "../../theme/colors";
 
@@ -18,7 +17,7 @@ export default function LoginScreen({ navigation }: any) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const setAuth = useAuthStore((s) => s.setAuth);
+  const login = useAuthStore((s) => s.login);
 
   async function handleLogin() {
     if (!email || !password) {
@@ -30,12 +29,7 @@ export default function LoginScreen({ navigation }: any) {
       setLoading(true);
       setError(null);
 
-      const result = await apiPost<AuthResponse>("/auth/login", {
-        email,
-        password,
-      });
-
-      setAuth(result);
+      await login(email, password);
       navigation.replace("MainTabs");
     } catch (err: any) {
       if (err?.message === "INVALID_CREDENTIALS") {

--- a/allwain/src/screens/Auth/RegisterScreen.tsx
+++ b/allwain/src/screens/Auth/RegisterScreen.tsx
@@ -3,11 +3,10 @@ import {
   View,
   Text,
   TextInput,
-  Button,
+  TouchableOpacity,
   StyleSheet,
   ActivityIndicator,
 } from "react-native";
-import { apiPost, AuthResponse } from "../../config/api";
 import { useAuthStore } from "../../store/auth.store";
 import { colors } from "../../theme/colors";
 
@@ -22,7 +21,7 @@ export default function RegisterScreen({ navigation }: any) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const setAuth = useAuthStore((s) => s.setAuth);
+  const register = useAuthStore((s) => s.register);
 
   async function handleRegister() {
     if (!name || !email || !password || !role) {
@@ -34,14 +33,7 @@ export default function RegisterScreen({ navigation }: any) {
       setLoading(true);
       setError(null);
 
-      const result = await apiPost<AuthResponse>("/auth/register", {
-        name,
-        email,
-        password,
-        role,
-      });
-
-      setAuth(result);
+      await register(name, email, password);
       navigation.replace("MainTabs");
     } catch (err: any) {
       if (err?.message === "EMAIL_ALREADY_EXISTS") {

--- a/allwain/src/theme/colors.ts
+++ b/allwain/src/theme/colors.ts
@@ -1,6 +1,6 @@
 export const colors = {
-  salmon: "#FF8F7A", // fondo principal
-  dark: "#403F3E", // texto principal y botones
+  salmon: "#FF795A", // fondo principal
+  dark: "#404041", // texto principal y botones
   white: "#FFFFFF", // texto claro y fondos internos
   line: "rgba(64,64,65,0.2)", // bordes suaves
   muted: "rgba(64,64,65,0.5)", // placeholder y textos secundarios

--- a/backend/data/database.json
+++ b/backend/data/database.json
@@ -1,0 +1,62 @@
+{
+  "users": [
+    {
+      "id": "1",
+      "name": "Admin Demo",
+      "email": "admin@newmersive.local",
+      "passwordHash": "$2a$10$Ljb/uUGMma.UWeFZ1lok6ubGIi2wZoa8dhTAZur6gvVuLMHAuEkTW",
+      "role": "admin",
+      "createdAt": "2024-01-01T00:00:00.000Z"
+    }
+  ],
+  "offers": [
+    {
+      "id": "offer-trueqia-1",
+      "title": "Edición de video para evento",
+      "description": "Montaje completo con ajustes de color y audio.",
+      "tokens": 80,
+      "owner": "trueqia",
+      "category": "creativos"
+    },
+    {
+      "id": "offer-trueqia-2",
+      "title": "Mentoría en IA aplicada",
+      "description": "Sesión 1 a 1 para integrar IA en flujos de trabajo.",
+      "tokens": 120,
+      "owner": "trueqia",
+      "category": "formación"
+    },
+    {
+      "id": "offer-allwain-1",
+      "title": "Descuento en café de especialidad",
+      "description": "Pack degustación 3 orígenes con envío 24h",
+      "tokens": 30,
+      "owner": "allwain",
+      "category": "gourmet"
+    },
+    {
+      "id": "offer-allwain-2",
+      "title": "Revisión de etiquetas nutricionales",
+      "description": "Analizamos tu código QR y devolvemos sugerencias",
+      "tokens": 45,
+      "owner": "allwain",
+      "category": "análisis"
+    }
+  ],
+  "trades": [
+    {
+      "id": "trade-1",
+      "title": "Trueque de horas de diseño",
+      "status": "activo",
+      "participants": ["trueqia-demo@newmersive.app", "company@trueqia.app"],
+      "tokens": 150
+    },
+    {
+      "id": "trade-2",
+      "title": "Alianza para campaña social",
+      "status": "negociando",
+      "participants": ["marca@allwain.com", "creador@trueqia.app"],
+      "tokens": 90
+    }
+  ]
+}

--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -1,15 +1,27 @@
 import { Request, Response } from "express";
-import { registerUser, loginUser } from "../services/auth.service";
+import { loginUser, registerUser, getUserProfile } from "../services/auth.service";
+import { AuthRequest } from "../middleware/auth.middleware";
 import { UserRole } from "../shared/types";
+
+const allowedRoles: UserRole[] = ["user", "company", "admin", "buyer"];
 
 export async function postRegister(req: Request, res: Response) {
   try {
     const { name, email, password, role } = req.body as any;
-    if (!name || !email || !password) return res.status(400).json({ error: "MISSING_FIELDS" });
-    const result = await registerUser(name, email, password, role || "user");
+    if (!name || !email || !password) {
+      return res.status(400).json({ error: "MISSING_FIELDS" });
+    }
+
+    const normalizedRole: UserRole = allowedRoles.includes(role)
+      ? role
+      : "user";
+
+    const result = await registerUser(name, email, password, normalizedRole);
     return res.status(201).json(result);
   } catch (err: any) {
-    if (err.message === "EMAIL_ALREADY_EXISTS") return res.status(409).json({ error: "EMAIL_ALREADY_EXISTS" });
+    if (err.message === "EMAIL_ALREADY_EXISTS") {
+      return res.status(409).json({ error: "EMAIL_ALREADY_EXISTS" });
+    }
     return res.status(500).json({ error: "INTERNAL_ERROR" });
   }
 }
@@ -17,11 +29,22 @@ export async function postRegister(req: Request, res: Response) {
 export async function postLogin(req: Request, res: Response) {
   try {
     const { email, password } = req.body as any;
-    if (!email || !password) return res.status(400).json({ error: "MISSING_FIELDS" });
+    if (!email || !password) {
+      return res.status(400).json({ error: "MISSING_FIELDS" });
+    }
     const result = await loginUser(email, password);
     return res.status(200).json(result);
   } catch (err: any) {
-    if (err.message === "INVALID_CREDENTIALS") return res.status(401).json({ error: "INVALID_CREDENTIALS" });
+    if (err.message === "INVALID_CREDENTIALS") {
+      return res.status(401).json({ error: "INVALID_CREDENTIALS" });
+    }
     return res.status(500).json({ error: "INTERNAL_ERROR" });
   }
+}
+
+export function getProfile(req: AuthRequest, res: Response) {
+  if (!req.user) return res.status(401).json({ error: "UNAUTHORIZED" });
+  const profile = getUserProfile(req.user.id);
+  if (!profile) return res.status(404).json({ error: "NOT_FOUND" });
+  return res.json({ user: profile });
 }

--- a/backend/src/routes/allwain.routes.ts
+++ b/backend/src/routes/allwain.routes.ts
@@ -1,15 +1,20 @@
 import { Router } from "express";
 import { authRequired, AuthRequest } from "../middleware/auth.middleware";
+import { listOffers } from "../services/market.service";
 
-const router=Router();
+const router = Router();
 
-router.get("/scan-demo", authRequired, (req:AuthRequest,res)=>{
+router.get("/scan-demo", authRequired, (req: AuthRequest, res) => {
   res.json({
-    result:"Etiqueta leída",
-    productName:"Café molido",
-    suggestions:["Tienda A","Tienda B"],
-    user:req.user?.email
+    result: "Etiqueta leída",
+    productName: "Café molido",
+    suggestions: ["Tienda A", "Tienda B"],
+    user: req.user?.email,
   });
+});
+
+router.get("/offers", authRequired, (_req, res) => {
+  res.json({ items: listOffers("allwain") });
 });
 
 export default router;

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -1,6 +1,11 @@
 import { Router } from "express";
-import { postLogin, postRegister } from "../controllers/auth.controller";
-const router=Router();
+import { getProfile, postLogin, postRegister } from "../controllers/auth.controller";
+import { authRequired } from "../middleware/auth.middleware";
+
+const router = Router();
+
 router.post("/register", postRegister);
 router.post("/login", postLogin);
+router.get("/me", authRequired, getProfile);
+
 export default router;

--- a/backend/src/routes/health.routes.ts
+++ b/backend/src/routes/health.routes.ts
@@ -1,3 +1,8 @@
-import { Router } from "express";import { ENV } from "../config/env";
-const router=Router();router.get("/health",(_req,res)=>res.json({ok:true,env:ENV.NODE_ENV}));
+import { Router } from "express";
+import { ENV } from "../config/env";
+
+const router = Router();
+
+router.get("/health", (_req, res) => res.json({ ok: true, env: ENV.NODE_ENV }));
+
 export default router;

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -5,10 +5,12 @@ import trueqiaRoutes from "./trueqia.routes";
 import allwainRoutes from "./allwain.routes";
 import adminRoutes from "./admin.routes";
 
-const router=Router();
-router.use("/",healthRoutes);
-router.use("/auth",authRoutes);
-router.use("/trueqia",trueqiaRoutes);
-router.use("/allwain",allwainRoutes);
-router.use("/admin",adminRoutes);
+const router = Router();
+
+router.use("/", healthRoutes);
+router.use("/auth", authRoutes);
+router.use("/trueqia", trueqiaRoutes);
+router.use("/allwain", allwainRoutes);
+router.use("/admin", adminRoutes);
+
 export default router;

--- a/backend/src/routes/trueqia.routes.ts
+++ b/backend/src/routes/trueqia.routes.ts
@@ -1,19 +1,21 @@
 import { Router } from "express";
 import { authRequired, AuthRequest } from "../middleware/auth.middleware";
 import { generateDemoContract } from "../ia/contracts.service";
+import { listOffers, listTrades } from "../services/market.service";
 
-const router=Router();
+const router = Router();
 
-router.get("/offers", authRequired, (req:AuthRequest,res)=>{
-  res.json({ items:[
-    {id:"1",title:"Clases de IA"},
-    {id:"2",title:"Diseño logo"}
-  ], user:req.user });
+router.get("/offers", authRequired, (req: AuthRequest, res) => {
+  res.json({ items: listOffers("trueqia"), user: req.user });
 });
 
-router.post("/contracts/preview", authRequired,(req:AuthRequest,res)=>{
+router.get("/trades", authRequired, (_req, res) => {
+  res.json({ items: listTrades() });
+});
+
+router.post("/contracts/preview", authRequired, (req: AuthRequest, res) => {
   const text = generateDemoContract(req.body);
-  res.json({ contractText:text });
+  res.json({ contractText: text });
 });
 
 export default router;

--- a/backend/src/services/data.store.ts
+++ b/backend/src/services/data.store.ts
@@ -1,0 +1,144 @@
+import fs from "fs";
+import path from "path";
+import { Offer, Trade, User } from "../shared/types";
+
+interface Database {
+  users: User[];
+  offers: Offer[];
+  trades: Trade[];
+}
+
+const DATA_FILE =
+  process.env.DATA_FILE || path.join(__dirname, "../../data/database.json");
+
+let cache: Database | null = null;
+
+const defaultData: Database = {
+  users: [],
+  offers: [
+    {
+      id: "offer-trueqia-1",
+      title: "Edición de video para evento",
+      description: "Montaje completo con ajustes de color y audio.",
+      tokens: 80,
+      owner: "trueqia",
+      category: "creativos",
+    },
+    {
+      id: "offer-trueqia-2",
+      title: "Mentoría en IA aplicada",
+      description: "Sesión 1 a 1 para integrar IA en flujos de trabajo.",
+      tokens: 120,
+      owner: "trueqia",
+      category: "formación",
+    },
+    {
+      id: "offer-allwain-1",
+      title: "Descuento en café de especialidad",
+      description: "Pack degustación 3 orígenes con envío 24h",
+      tokens: 30,
+      owner: "allwain",
+      category: "gourmet",
+    },
+    {
+      id: "offer-allwain-2",
+      title: "Revisión de etiquetas nutricionales",
+      description: "Analizamos tu código QR y devolvemos sugerencias",
+      tokens: 45,
+      owner: "allwain",
+      category: "análisis",
+    },
+  ],
+  trades: [
+    {
+      id: "trade-1",
+      title: "Trueque de horas de diseño",
+      status: "activo",
+      participants: ["trueqia-demo@newmersive.app", "company@trueqia.app"],
+      tokens: 150,
+    },
+    {
+      id: "trade-2",
+      title: "Alianza para campaña social",
+      status: "negociando",
+      participants: ["marca@allwain.com", "creador@trueqia.app"],
+      tokens: 90,
+    },
+  ],
+};
+
+function ensureDataDir() {
+  const dir = path.dirname(DATA_FILE);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+function loadFromDisk(): Database {
+  ensureDataDir();
+  if (!fs.existsSync(DATA_FILE)) {
+    fs.writeFileSync(DATA_FILE, JSON.stringify(defaultData, null, 2));
+    return { ...defaultData };
+  }
+
+  const raw = fs.readFileSync(DATA_FILE, "utf8");
+  if (!raw) return { ...defaultData };
+
+  const parsed = JSON.parse(raw) as Database;
+  return {
+    users: parsed.users || [],
+    offers: parsed.offers || defaultData.offers,
+    trades: parsed.trades || defaultData.trades,
+  };
+}
+
+function saveToDisk(data: Database) {
+  ensureDataDir();
+  fs.writeFileSync(DATA_FILE, JSON.stringify(data, null, 2));
+}
+
+export function getDatabase(): Database {
+  if (!cache) {
+    cache = loadFromDisk();
+  }
+  return cache;
+}
+
+export function persistDatabase() {
+  if (!cache) return;
+  saveToDisk(cache);
+}
+
+export function resetDatabase(data: Partial<Database>) {
+  cache = {
+    users: data.users ?? [],
+    offers: data.offers ?? defaultData.offers,
+    trades: data.trades ?? defaultData.trades,
+  };
+  persistDatabase();
+}
+
+export function upsertUser(user: User) {
+  const db = getDatabase();
+  const existingIndex = db.users.findIndex((u) => u.id === user.id);
+  if (existingIndex >= 0) {
+    db.users[existingIndex] = user;
+  } else {
+    db.users.push(user);
+  }
+  persistDatabase();
+}
+
+export function setUsers(users: User[]) {
+  const db = getDatabase();
+  db.users = users;
+  persistDatabase();
+}
+
+export function getOffersForOwner(owner: "trueqia" | "allwain") {
+  return getDatabase().offers.filter((offer) => offer.owner === owner);
+}
+
+export function getTrades() {
+  return getDatabase().trades;
+}

--- a/backend/src/services/market.service.ts
+++ b/backend/src/services/market.service.ts
@@ -1,0 +1,10 @@
+import { getOffersForOwner, getTrades } from "./data.store";
+import { Offer, Trade } from "../shared/types";
+
+export function listOffers(owner: "trueqia" | "allwain"): Offer[] {
+  return getOffersForOwner(owner);
+}
+
+export function listTrades(): Trade[] {
+  return getTrades();
+}

--- a/backend/src/shared/types.ts
+++ b/backend/src/shared/types.ts
@@ -6,15 +6,34 @@ export interface User {
   email: string;
   passwordHash: string;
   role: UserRole;
-  createdAt: Date;
+  createdAt: string;
 }
 
 export interface AuthTokenResponse {
   token: string;
-  user: {
-    id: string;
-    name: string;
-    email: string;
-    role: UserRole;
-  };
+  user: AuthUser;
+}
+
+export interface AuthUser {
+  id: string;
+  name: string;
+  email: string;
+  role: UserRole;
+}
+
+export interface Offer {
+  id: string;
+  title: string;
+  description: string;
+  tokens: number;
+  owner: "trueqia" | "allwain";
+  category: string;
+}
+
+export interface Trade {
+  id: string;
+  title: string;
+  status: string;
+  participants: string[];
+  tokens: number;
 }

--- a/trueqia/App.tsx
+++ b/trueqia/App.tsx
@@ -1,10 +1,23 @@
 import React from "react";
-import { NavigationContainer } from "@react-navigation/native";
+import { NavigationContainer, DefaultTheme } from "@react-navigation/native";
 import RootNavigator from "./src/navigation/RootNavigator";
+import { colors } from "./src/config/theme";
+
+const navigationTheme = {
+  ...DefaultTheme,
+  colors: {
+    ...DefaultTheme.colors,
+    background: colors.background,
+    card: colors.background,
+    text: colors.text,
+    primary: colors.primary,
+    border: colors.border,
+  },
+};
 
 export default function App() {
   return (
-    <NavigationContainer>
+    <NavigationContainer theme={navigationTheme}>
       <RootNavigator />
     </NavigationContainer>
   );

--- a/trueqia/src/config/api.ts
+++ b/trueqia/src/config/api.ts
@@ -1,4 +1,5 @@
-export const API_BASE_URL = "http://localhost:4000/api";
+export const API_BASE_URL =
+  process.env.EXPO_PUBLIC_API_BASE_URL || "http://localhost:4000/api";
 
 export interface AuthResponse {
   token: string;

--- a/trueqia/src/screens/Auth/AuthScreen.tsx
+++ b/trueqia/src/screens/Auth/AuthScreen.tsx
@@ -17,14 +17,15 @@ export default function AuthScreen() {
   const login = useAuthStore((s) => s.login);
   const register = useAuthStore((s) => s.register);
 
+  const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
   const handleAuth = async (mode: "login" | "register") => {
-    if (!email || !password) {
-      setError("Ingresa email y contraseña");
+    if (!email || !password || (mode === "register" && !name)) {
+      setError("Completa nombre, email y contraseña");
       return;
     }
 
@@ -35,10 +36,10 @@ export default function AuthScreen() {
       if (mode === "login") {
         await login(email, password);
       } else {
-        await register(email, password);
+        await register(name, email, password);
       }
-    } catch (err) {
-      setError("Ocurrió un error. Inténtalo de nuevo.");
+    } catch (err: any) {
+      setError(err?.message || "Ocurrió un error. Inténtalo de nuevo.");
     } finally {
       setLoading(false);
     }
@@ -56,6 +57,13 @@ export default function AuthScreen() {
         </View>
 
         <View style={styles.form}>
+          <TextInput
+            style={styles.input}
+            placeholder="Nombre"
+            placeholderTextColor={colors.muted}
+            value={name}
+            onChangeText={setName}
+          />
           <TextInput
             style={styles.input}
             placeholder="Email"

--- a/trueqia/src/screens/Auth/LoginScreen.tsx
+++ b/trueqia/src/screens/Auth/LoginScreen.tsx
@@ -3,21 +3,20 @@ import {
   View,
   Text,
   TextInput,
-  Button,
+  TouchableOpacity,
   StyleSheet,
   ActivityIndicator,
 } from "react-native";
-import { apiPost, AuthResponse } from "../../config/api";
+import { colors } from "../../config/theme";
 import { useAuthStore } from "../../store/auth.store";
 
 export default function LoginScreen({ navigation }: any) {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const setAuth = useAuthStore((s) => s.setAuth);
+  const login = useAuthStore((s) => s.login);
 
   async function handleLogin() {
     if (!email || !password) {
@@ -28,13 +27,7 @@ export default function LoginScreen({ navigation }: any) {
     try {
       setLoading(true);
       setError(null);
-
-      const result = await apiPost<AuthResponse>("/auth/login", {
-        email,
-        password,
-      });
-
-      setAuth(result);
+      await login(email, password);
       navigation.replace("MainTabs");
     } catch (err: any) {
       if (err?.message === "INVALID_CREDENTIALS") {
@@ -54,6 +47,7 @@ export default function LoginScreen({ navigation }: any) {
       <TextInput
         style={styles.input}
         placeholder="Email"
+        placeholderTextColor={colors.muted}
         autoCapitalize="none"
         keyboardType="email-address"
         value={email}
@@ -63,6 +57,7 @@ export default function LoginScreen({ navigation }: any) {
       <TextInput
         style={styles.input}
         placeholder="Contraseña"
+        placeholderTextColor={colors.muted}
         secureTextEntry
         value={password}
         onChangeText={setPassword}
@@ -70,30 +65,53 @@ export default function LoginScreen({ navigation }: any) {
 
       {error && <Text style={styles.error}>{error}</Text>}
 
-      {loading ? (
-        <ActivityIndicator />
-      ) : (
-        <Button title="Entrar" onPress={handleLogin} />
-      )}
+      <TouchableOpacity
+        style={[styles.primaryButton, loading && styles.buttonDisabled]}
+        onPress={handleLogin}
+        disabled={loading}
+      >
+        {loading ? (
+          <ActivityIndicator color="#FFFFFF" />
+        ) : (
+          <Text style={styles.primaryButtonText}>Entrar</Text>
+        )}
+      </TouchableOpacity>
 
-      <View style={{ height: 12 }} />
-      <Button
-        title="Crear cuenta"
+      <TouchableOpacity
+        style={styles.secondaryButton}
         onPress={() => navigation.navigate("Register")}
-      />
+      >
+        <Text style={styles.secondaryText}>Crear cuenta</Text>
+      </TouchableOpacity>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, justifyContent: "center", padding: 24 },
-  title: { fontSize: 24, fontWeight: "bold", marginBottom: 16 },
+  container: { flex: 1, justifyContent: "center", padding: 24, backgroundColor: colors.background },
+  title: { fontSize: 24, fontWeight: "bold", marginBottom: 16, color: colors.text },
   input: {
     borderWidth: 1,
-    borderColor: "#ccc",
-    borderRadius: 6,
-    padding: 10,
+    borderColor: colors.border,
+    borderRadius: 10,
+    padding: 12,
     marginBottom: 12,
+    color: colors.text,
+    backgroundColor: "#FFFFFF",
   },
-  error: { color: "red", marginBottom: 12 },
+  error: { color: "#B3261E", marginBottom: 12 },
+  primaryButton: {
+    backgroundColor: colors.primary,
+    paddingVertical: 14,
+    borderRadius: 12,
+    alignItems: "center",
+  },
+  primaryButtonText: { color: "#FFFFFF", fontWeight: "700" },
+  buttonDisabled: { opacity: 0.7 },
+  secondaryButton: {
+    marginTop: 12,
+    paddingVertical: 12,
+    alignItems: "center",
+  },
+  secondaryText: { color: colors.primary, fontWeight: "700" },
 });

--- a/trueqia/src/screens/Auth/RegisterScreen.tsx
+++ b/trueqia/src/screens/Auth/RegisterScreen.tsx
@@ -3,40 +3,32 @@ import {
   View,
   Text,
   TextInput,
-  Button,
+  TouchableOpacity,
   StyleSheet,
   ActivityIndicator,
 } from "react-native";
-import { apiPost, AuthResponse } from "../../config/api";
+import { colors } from "../../config/theme";
 import { useAuthStore } from "../../store/auth.store";
 
 export default function RegisterScreen({ navigation }: any) {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const setAuth = useAuthStore((s) => s.setAuth);
+  const register = useAuthStore((s) => s.register);
 
   async function handleRegister() {
     if (!name || !email || !password) {
-      setError("Faltan campos obligatorios");
+      setError("Completa nombre, email y contraseña");
       return;
     }
 
     try {
       setLoading(true);
       setError(null);
-
-      const result = await apiPost<AuthResponse>("/auth/register", {
-        name,
-        email,
-        password,
-      });
-
-      setAuth(result);
+      await register(name, email, password);
       navigation.replace("MainTabs");
     } catch (err: any) {
       if (err?.message === "EMAIL_ALREADY_EXISTS") {
@@ -56,6 +48,7 @@ export default function RegisterScreen({ navigation }: any) {
       <TextInput
         style={styles.input}
         placeholder="Nombre"
+        placeholderTextColor={colors.muted}
         value={name}
         onChangeText={setName}
       />
@@ -63,6 +56,7 @@ export default function RegisterScreen({ navigation }: any) {
       <TextInput
         style={styles.input}
         placeholder="Email"
+        placeholderTextColor={colors.muted}
         autoCapitalize="none"
         keyboardType="email-address"
         value={email}
@@ -72,6 +66,7 @@ export default function RegisterScreen({ navigation }: any) {
       <TextInput
         style={styles.input}
         placeholder="Contraseña"
+        placeholderTextColor={colors.muted}
         secureTextEntry
         value={password}
         onChangeText={setPassword}
@@ -79,24 +74,53 @@ export default function RegisterScreen({ navigation }: any) {
 
       {error && <Text style={styles.error}>{error}</Text>}
 
-      {loading ? (
-        <ActivityIndicator />
-      ) : (
-        <Button title="Registrar y entrar" onPress={handleRegister} />
-      )}
+      <TouchableOpacity
+        style={[styles.primaryButton, loading && styles.buttonDisabled]}
+        onPress={handleRegister}
+        disabled={loading}
+      >
+        {loading ? (
+          <ActivityIndicator color="#FFFFFF" />
+        ) : (
+          <Text style={styles.primaryButtonText}>Registrar y entrar</Text>
+        )}
+      </TouchableOpacity>
+
+      <TouchableOpacity
+        style={styles.secondaryButton}
+        onPress={() => navigation.navigate("Login")}
+      >
+        <Text style={styles.secondaryText}>Ya tengo cuenta</Text>
+      </TouchableOpacity>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, justifyContent: "center", padding: 24 },
-  title: { fontSize: 24, fontWeight: "bold", marginBottom: 16 },
+  container: { flex: 1, justifyContent: "center", padding: 24, backgroundColor: colors.background },
+  title: { fontSize: 24, fontWeight: "bold", marginBottom: 16, color: colors.text },
   input: {
     borderWidth: 1,
-    borderColor: "#ccc",
-    borderRadius: 6,
-    padding: 10,
+    borderColor: colors.border,
+    borderRadius: 10,
+    padding: 12,
     marginBottom: 12,
+    color: colors.text,
+    backgroundColor: "#FFFFFF",
   },
-  error: { color: "red", marginBottom: 12 },
+  error: { color: "#B3261E", marginBottom: 12 },
+  primaryButton: {
+    backgroundColor: colors.primary,
+    paddingVertical: 14,
+    borderRadius: 12,
+    alignItems: "center",
+  },
+  primaryButtonText: { color: "#FFFFFF", fontWeight: "700" },
+  buttonDisabled: { opacity: 0.7 },
+  secondaryButton: {
+    marginTop: 12,
+    paddingVertical: 12,
+    alignItems: "center",
+  },
+  secondaryText: { color: colors.primary, fontWeight: "700" },
 });

--- a/trueqia/src/screens/Profile/ProfileScreen.tsx
+++ b/trueqia/src/screens/Profile/ProfileScreen.tsx
@@ -7,12 +7,11 @@ export default function ProfileScreen() {
   const user = useAuthStore((s) => s.user);
   const logout = useAuthStore((s) => s.logout);
 
-  const profile =
-    user ?? {
-      name: "Usuario TRUEQIA",
-      email: "usuario@trueqia.com",
-      location: "Valencia, España",
-    };
+  const profile = {
+    name: user?.name ?? "Usuario TRUEQIA",
+    email: user?.email ?? "usuario@trueqia.com",
+    location: "Valencia, España",
+  };
 
   return (
     <View style={styles.container}>

--- a/trueqia/src/store/auth.store.ts
+++ b/trueqia/src/store/auth.store.ts
@@ -1,47 +1,33 @@
 import { create } from "zustand";
+import { apiPost, AuthResponse } from "../config/api";
 
 type User = {
+  id: string;
   name: string;
   email: string;
-  location: string;
+  role: string;
 };
 
 interface AuthState {
   token: string | null;
   user: User | null;
+  setAuth: (payload: AuthResponse) => void;
   login: (email: string, password: string) => Promise<void>;
-  register: (email: string, password: string) => Promise<void>;
+  register: (name: string, email: string, password: string) => Promise<void>;
   logout: () => void;
 }
-
-const MOCK_LOCATION = "Valencia, España";
 
 export const useAuthStore = create<AuthState>((set) => ({
   token: null,
   user: null,
-  login: async (email) => {
-    await new Promise((resolve) => setTimeout(resolve, 600));
-
-    set({
-      token: "mock-token",
-      user: {
-        name: "Usuario TRUEQIA",
-        email,
-        location: MOCK_LOCATION,
-      },
-    });
+  setAuth: ({ token, user }) => set({ token, user }),
+  login: async (email, password) => {
+    const res = await apiPost<AuthResponse>("/auth/login", { email, password });
+    set({ token: res.token, user: res.user });
   },
-  register: async (email) => {
-    await new Promise((resolve) => setTimeout(resolve, 600));
-
-    set({
-      token: "mock-token",
-      user: {
-        name: "Nueva cuenta TRUEQIA",
-        email,
-        location: MOCK_LOCATION,
-      },
-    });
+  register: async (name, email, password) => {
+    const res = await apiPost<AuthResponse>("/auth/register", { name, email, password });
+    set({ token: res.token, user: res.user });
   },
   logout: () => set({ token: null, user: null }),
 }));


### PR DESCRIPTION
## Summary
- add file-based persistence, shared offers/trades data, and profile/auth routes for the unified backend
- expose consistent JWT authentication, roles, and admin/AI/demo endpoints for both Allwain and TRUEQIA clients
- wire both mobile apps to the backend with dedicated themes, env-based API URLs, and name-aware login/registration flows

## Testing
- npm test -- --test-timeout=5000 (passes, requires manual exit after completion)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dea1bfb848326b8b754008f980f4e)