### PR TITLE
Add Expo app configuration for TrueQIA and Allwain

### DIFF
--- a/allwain/app.json
+++ b/allwain/app.json
@@ -1,0 +1,10 @@
+{
+  "expo": {
+    "name": "Allwain",
+    "slug": "allwain",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "entryPoint": "./node_modules/expo/AppEntry.js",
+    "assetBundlePatterns": ["**/*"]
+  }
+}

--- a/allwain/babel.config.js
+++ b/allwain/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: ['react-native-reanimated/plugin'],
+  };
+};

--- a/allwain/eslint.config.js
+++ b/allwain/eslint.config.js
@@ -1,0 +1,8 @@
+module.exports = [
+  {
+    ignores: ["**/node_modules/**", "**/dist/**"],
+  },
+  {
+    extends: ["expo"],
+  },
+];

--- a/allwain/package.json
+++ b/allwain/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "allwain",
+  "version": "1.0.0",
+  "private": true,
+  "main": "./node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web",
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@react-navigation/bottom-tabs": "^6.5.20",
+    "@react-navigation/native": "^6.1.17",
+    "@react-navigation/native-stack": "^6.9.26",
+    "expo": "~51.0.24",
+    "react": "18.3.1",
+    "react-native": "0.76.6",
+    "react-native-gesture-handler": "~2.16.2",
+    "react-native-reanimated": "~3.12.1",
+    "react-native-safe-area-context": "4.10.5",
+    "react-native-screens": "~4.8.1",
+    "zustand": "^4.5.5"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.25.2",
+    "@types/react": "~18.3.4",
+    "@types/react-native": "0.76.0",
+    "eslint": "^9.6.0",
+    "eslint-config-expo": "^7.1.1",
+    "typescript": "~5.3.3"
+  }
+}

--- a/allwain/tsconfig.json
+++ b/allwain/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "jsx": "react-native",
+    "allowJs": false,
+    "noEmit": true,
+    "isolatedModules": true,
+    "types": ["react", "react-native"]
+  },
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules", "babel.config.js", "metro.config.js"]
+}

--- a/trueqia/app.json
+++ b/trueqia/app.json
@@ -1,0 +1,10 @@
+{
+  "expo": {
+    "name": "TrueQIA",
+    "slug": "trueqia",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "entryPoint": "./node_modules/expo/AppEntry.js",
+    "assetBundlePatterns": ["**/*"]
+  }
+}

--- a/trueqia/babel.config.js
+++ b/trueqia/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: ['react-native-reanimated/plugin'],
+  };
+};

--- a/trueqia/eslint.config.js
+++ b/trueqia/eslint.config.js
@@ -1,0 +1,8 @@
+module.exports = [
+  {
+    ignores: ["**/node_modules/**", "**/dist/**"],
+  },
+  {
+    extends: ["expo"],
+  },
+];

--- a/trueqia/package.json
+++ b/trueqia/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "trueqia",
+  "version": "1.0.0",
+  "private": true,
+  "main": "./node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web",
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@react-navigation/bottom-tabs": "^6.5.20",
+    "@react-navigation/native": "^6.1.17",
+    "@react-navigation/native-stack": "^6.9.26",
+    "expo": "~51.0.24",
+    "react": "18.3.1",
+    "react-native": "0.76.6",
+    "react-native-gesture-handler": "~2.16.2",
+    "react-native-reanimated": "~3.12.1",
+    "react-native-safe-area-context": "4.10.5",
+    "react-native-screens": "~4.8.1",
+    "zustand": "^4.5.5"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.25.2",
+    "@types/react": "~18.3.4",
+    "@types/react-native": "0.76.0",
+    "eslint": "^9.6.0",
+    "eslint-config-expo": "^7.1.1",
+    "typescript": "~5.3.3"
+  }
+}

--- a/trueqia/tsconfig.json
+++ b/trueqia/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "jsx": "react-native",
+    "allowJs": false,
+    "noEmit": true,
+    "isolatedModules": true,
+    "types": ["react", "react-native"]
+  },
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules", "babel.config.js", "metro.config.js"]
+}


### PR DESCRIPTION
## Summary
- add Expo SDK 51 aligned package.json files for TrueQIA and Allwain with navigation and state dependencies plus standard scripts
- introduce Expo app.json metadata, TypeScript, ESLint, and Babel configs to support linting and bundling with Reanimated

## Testing
- npm install *(fails: registry responded 403 in this environment)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e05fab4d08326a7268571bebefa86)