### PR TITLE
Fix navigation root setup for web compatibility

### DIFF
--- a/trueqia/src/navigation/RootNavigator.tsx
+++ b/trueqia/src/navigation/RootNavigator.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
 import AuthScreen from "../screens/Auth/AuthScreen";
 import MainTabs from "./MainTabs";
 import { useAuthStore } from "../store/auth.store";
@@ -10,12 +11,14 @@ export default function RootNavigator() {
   const user = useAuthStore((s) => s.user);
 
   return (
-    <Stack.Navigator screenOptions={{ headerShown: false }}>
-      {user ? (
-        <Stack.Screen name="MainTabs" component={MainTabs} />
-      ) : (
-        <Stack.Screen name="Auth" component={AuthScreen} />
-      )}
-    </Stack.Navigator>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <Stack.Navigator screenOptions={{ headerShown: false }}>
+        {user ? (
+          <Stack.Screen name="MainTabs" component={MainTabs} />
+        ) : (
+          <Stack.Screen name="Auth" component={AuthScreen} />
+        )}
+      </Stack.Navigator>
+    </GestureHandlerRootView>
   );
 }


### PR DESCRIPTION
## Summary
- wrap the navigation stack in GestureHandlerRootView to ensure gesture support across platforms
- keep stack navigator configuration intact while maintaining hidden headers

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e26c48e7c8326b5d738911ebbaca8)