### PR TITLE
Align Expo dependencies for SDK 54

### DIFF
--- a/allwain/package.json
+++ b/allwain/package.json
@@ -18,10 +18,10 @@
     "expo": "~54.0.0",
     "react": "18.3.1",
     "react-native": "0.75.4",
-    "react-native-gesture-handler": "~2.16.2",
+    "react-native-gesture-handler": "~2.16.1",
     "react-native-reanimated": "~3.16.1",
-    "react-native-safe-area-context": "~4.11.5",
-    "react-native-screens": "~4.8.1",
+    "react-native-safe-area-context": "~4.10.5",
+    "react-native-screens": "~4.8.0",
     "zustand": "^4.5.5"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- adjust native dependency versions to the Expo SDK 54 supported releases for gesture handler, reanimated, safe-area context, and screens

## Testing
- npm install --legacy-peer-deps *(fails: npm registry access returns 403 errors in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e26e1d4d0832693e2aaea5ad9a200)