### PR TITLE
Align Expo SDK 54 dependencies for ALLWAIN

### DIFF
--- a/allwain/package.json
+++ b/allwain/package.json
@@ -20,8 +20,8 @@
     "react-native": "0.75.4",
     "react-native-gesture-handler": "~2.16.2",
     "react-native-reanimated": "~3.16.1",
-    "react-native-safe-area-context": "~4.11.5",
-    "react-native-screens": "~4.8.1",
+    "react-native-safe-area-context": "~4.10.5",
+    "react-native-screens": "~4.7.1",
     "zustand": "^4.5.5"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- align the native Expo dependencies to valid versions compatible with SDK 54

## Testing
- npm install --legacy-peer-deps *(fails: registry access blocked by proxy 403 Forbidden)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e28bdcf988326a63267c9cc6076c6)