### PR TITLE
Add architecture documentation for apps and backend

### DIFF
--- a/allwain/README.md
+++ b/allwain/README.md
@@ -1,0 +1,6 @@
+# Allwain (app móvil)
+
+App Expo/React Native enfocada en búsqueda, escaneo y ofertas con autenticación JWT y pestañas para Buscar, Ofertas y Perfil.
+
+- **Arquitectura detallada**: [docs/allwain-architecture.md](../docs/allwain-architecture.md).
+- **Backend asociado**: usa endpoints compartidos `/api/auth/*` y específicos `/api/allwain/*` descritos en [docs/backend-architecture.md](../docs/backend-architecture.md).

--- a/backend/README.md
+++ b/backend/README.md
@@ -2,6 +2,8 @@
 
 Backend en Node.js/TypeScript para las experiencias de **TRUEQIA** y **ALLWAIN**. Expone las rutas en `/api` y utiliza un almacenamiento JSON sencillo para usuarios, ofertas y transacciones demo.
 
+> 📄 Consulta el resumen de arquitectura en [docs/backend-architecture.md](../docs/backend-architecture.md).
+
 ## Requisitos
 - Node.js **20.x** (probado con la serie LTS actual)
 - npm **10.x**

--- a/docs/allwain-architecture.md
+++ b/docs/allwain-architecture.md
@@ -1,0 +1,51 @@
+# Arquitectura de Allwain (mobile)
+
+## Resumen funcional
+- **Qué es**: app móvil Expo/React Native enfocada en escaneo y búsqueda de productos/servicios con ofertas comisionadas. Comparte backend con TrueQIA pero con temática y UI diferente (paleta salmón).
+- **Diferencias clave**: flujo centrado en búsqueda y escaneo demo, invitados/compras con resultados sugeridos; sin trueques ni contratos.
+
+## Flujo principal de usuario
+1. Onboarding/Login en `AuthScreen` usando `/auth/register` o `/auth/login`.
+2. Pestañas principales (`MainTabs`):
+   - **Buscar**: entrada de texto y resultados sugeridos estáticos.
+   - **Ofertas**: listado demo de ofertas y comisión estimada.
+   - **Perfil**: datos del usuario y cierre de sesión.
+3. Desde secciones de Scan/Guests/Demo se simulan flujos de invitaciones, escaneo QR/etiquetas y resultados de AI pricing.
+
+## Mapa de pantallas
+| Pantalla | Propósito | Navegación | Stores/Hooks |
+| --- | --- | --- | --- |
+| Auth/AuthScreen | Formulario de login/registro unificado. | Stack raíz decide `MainTabs` tras autenticación. | `useAuthStore.login`, `useAuthStore.register` |
+| Auth/LoginScreen / Auth/RegisterScreen | Placeholders. | N/A | N/A |
+| Search/SearchScreen | Búsqueda con resultados mock y CTA de mejor precio. | N/A | Estado local |
+| Deals/DealsScreen | Tarjetas de ofertas demo con comisión y CTA de invitar. | N/A | N/A |
+| Offers/OffersScreen | Placeholder de ofertas (puente para integración backend). | N/A | N/A |
+| Scan/HomeScreen | Landing de escaneo con CTA hacia flujo de cámara/resultado. | Puede ir a `ScanScreen` / `ScanResultScreen` | Estado local |
+| Scan/ScanScreen | Simulación de escaneo de QR/etiqueta. | `ScanResultScreen` | Estado local |
+| Scan/ScanResultScreen | Resultado demo de lectura con sugerencias. | N/A | N/A |
+| Guests/GuestsScreen | Gestión de invitados/comisiones demo. | N/A | N/A |
+| Profile/ProfileScreen | Perfil del usuario y logout. | N/A | `useAuthStore.logout` |
+| Profile/ProfileMainScreen | Placeholder de perfil extendido. | N/A | N/A |
+| Demo/DemoLandingScreen / DemoScanResultScreen | Flujos demo de AI pricing/escaneo. | N/A | Estado local |
+| Admin/AdminDashboardScreen | Placeholder. | N/A | N/A |
+
+## Navegación
+- **Árbol**: `RootNavigator` (stack) muestra `AuthScreen` si no hay `user`; tras login carga `MainTabs` con pestañas `Buscar`, `Ofertas`, `Perfil`.
+- **Flujo**: abrir app → autenticarse → navegar entre pestañas; flujos de escaneo/invitados están enlazados mediante botones internos desde `ScanHome`/`Deals`.
+
+## Estado global / stores
+- **`auth.store.ts`**: igual que TrueQIA; gestiona `token`, `user`, `login`, `register`, `logout` usando `apiPost` hacia `/auth/login` y `/auth/register`.
+- No hay otros stores: resultados de búsqueda, escaneo, invitados y ofertas se mantienen en mocks o estado local.
+
+## Integración con el backend
+- **Autenticación**: `POST /auth/register`, `POST /auth/login`.
+- **Rutas específicas** (implementadas pero aún no conectadas en UI principal):
+  - `GET /allwain/scan-demo`: resultado de lectura de etiqueta.
+  - `GET /allwain/offers`: ofertas asociadas a Allwain.
+- **Endpoints compartidos con TrueQIA**: `/auth/*`; el backend diferencia propietario en `/trueqia/offers` vs `/allwain/offers`.
+
+## Inconsistencias / riesgos
+- Amplio uso de pantallas placeholder sin integración real.
+- No se consumen los endpoints `/allwain/scan-demo` ni `/allwain/offers` desde el código actual.
+- Falta manejo de errores de red y expiración de token; los datos de mock pueden divergir del backend.
+- Flujos de invitados y comisiones son únicamente estáticos; requiere modelado de datos real.

--- a/docs/backend-architecture.md
+++ b/docs/backend-architecture.md
@@ -1,0 +1,56 @@
+# Arquitectura del Backend
+
+## Resumen general
+- **Stack**: Node.js + Express + TypeScript. Persistencia en archivo JSON (`data/database.json`) mediante utilidades en `src/services/data.store.ts`. JWT para autenticación; bcrypt para hashes.
+- **Estructura**:
+  - `src/server.ts`: arranque de Express, montaje de `/api`.
+  - `src/routes`: definición de rutas agrupadas (`auth`, `trueqia`, `allwain`, `admin`, `health`).
+  - `src/controllers`: lógica HTTP para auth.
+  - `src/services`: servicios de dominio (auth, market, data store).
+  - `src/ia`: helpers demo (contratos, moderación).
+  - `src/middleware`: autenticación/roles.
+  - `data/`: archivo JSON con datos semilla.
+
+## Modelo de datos
+- Definido en `src/shared/types.ts`:
+  - **User**: `id`, `name`, `email`, `passwordHash`, `role` (`user|buyer|company|admin`), `createdAt`.
+  - **AuthUser/AuthTokenResponse**: versión pública sin `passwordHash` + token.
+  - **Offer**: `id`, `title`, `description`, `tokens`, `owner` (`trueqia|allwain`), `category`.
+  - **Trade**: `id`, `title`, `status`, `participants`, `tokens`.
+- **Relaciones**: usuarios asociados a autenticación/roles; ofertas se filtran por `owner`; trades contienen correos participantes. No hay relaciones en base de datos relacional, solo arrays en memoria/JSON.
+- **Almacenamiento** (`data.store.ts`):
+  - Lee/escribe JSON, inicializa ofertas y trades demo.
+  - Operaciones: `getDatabase`, `persistDatabase`, `resetDatabase`, `upsertUser`, `setUsers`, `getOffersForOwner`, `getTrades`.
+  - Seed automático de admin (`admin@newmersive.local` / `admin123`).
+
+## Tabla de endpoints (prefijo `/api`)
+| Método | Ruta | Descripción | Modelos | Auth |
+| --- | --- | --- | --- | --- |
+| GET | /health | Ping con `status` y `env`. | – | Público |
+| POST | /auth/register | Registra usuario (roles permitidos en whitelist) y devuelve token. | User | Público |
+| POST | /auth/login | Autentica y devuelve token. | User | Público |
+| GET | /auth/me | Perfil del usuario autenticado. | User | Bearer |
+| GET | /trueqia/offers | Ofertas filtradas por owner `trueqia`. | Offer | Bearer |
+| GET | /trueqia/trades | Lista de trades demo. | Trade | Bearer |
+| POST | /trueqia/contracts/preview | Devuelve texto de contrato demo generado en backend IA. | – | Bearer |
+| GET | /allwain/scan-demo | Respuesta mock de escaneo QR/etiqueta. | – | Bearer |
+| GET | /allwain/offers | Ofertas con owner `allwain`. | Offer | Bearer |
+| GET | /admin/dashboard | Ping protegido para admin. | – | Bearer (admin) |
+| GET | /admin/users | Lista pública de usuarios (sin password). | User | Bearer (admin) |
+| GET | /admin/ai/activity | Lista de eventos demo de moderación. | – | Bearer (admin) |
+
+### Consumo por apps
+- **TrueQIA**: `/auth/register`, `/auth/login`, `/trueqia/offers`, `/trueqia/contracts/preview` (trades aún no conectados en app), `/auth/me` disponible.
+- **Allwain**: `/auth/register`, `/auth/login`; las rutas `/allwain/scan-demo` y `/allwain/offers` están listas pero no se consumen en el código actual.
+
+## Autenticación y roles
+- Middleware `authRequired`: valida header `Authorization: Bearer <token>`, usa `jwt.verify` con `ENV.JWT_SECRET`; si es válido adjunta `{id,email,role}` en `req.user`.
+- Middleware `adminOnly`: requiere `req.user.role === "admin"`; responde 403 en caso contrario.
+- Tokens se firman a 7 días (`registerUser`/`loginUser`) y contienen `sub`, `email`, `role`.
+- Roles permitidos en registro: `user`, `company`, `admin`, `buyer` (fallback a `user`).
+
+## Tests
+- Suite en `tests/auth.spec.ts` con helper `TestClient`:
+  - Cubre registro y login (estado/estructura del token).
+  - Verifica middleware: rechazo sin token, token inválido, bloqueo de usuario no admin y acceso permitido a admin.
+- **Huecos**: no hay pruebas para rutas `trueqia/*`, `allwain/*`, persistencia, ni generación de contratos/moderación.

--- a/docs/trueqia-architecture.md
+++ b/docs/trueqia-architecture.md
@@ -1,0 +1,50 @@
+# Arquitectura de TrueQIA (mobile)
+
+## Resumen funcional
+- **Qué es**: aplicación móvil Expo/React Native centrada en trueques y colaboración, con navegación por pestañas para trueques, chat y perfil.
+- **Capacidades de usuario**: registro e inicio de sesión con token JWT, exploración de trueques destacados (mock), visualización de ofertas provenientes del backend, generación de previsualizaciones de contrato IA, mensajería simulada dentro de la app y gestión básica de perfil/cierre de sesión.
+
+## Mapa de pantallas (`src/screens`)
+
+| Pantalla | Propósito | Navega a | Stores/Hooks clave |
+| --- | --- | --- | --- |
+| Auth/AuthScreen | Registro/Login unificados con manejo de errores y loaders. | Con stack raíz decide redirección a `MainTabs` tras login. | `useAuthStore.login`, `useAuthStore.register` |
+| Auth/LoginScreen | Placeholder de login (no conectado). | N/A | N/A |
+| Auth/RegisterScreen | Placeholder de registro. | N/A | N/A |
+| Home/HomeScreen | Mensaje de bienvenida con datos del usuario. | N/A | `useAuthStore.user` |
+| Trades/TradesScreen | Lista mock de trueques destacados. | N/A | N/A |
+| Offers/OffersListScreen | Consume backend para listar ofertas y abrir previsualización de contrato. | `ContractPreview` | `useOffersStore` |
+| Contracts/ContractPreviewScreen | Genera contrato demo llamando al backend con datos de oferta/usuarios. | N/A | `apiAuthPost` |
+| Requests/RequestsListScreen | Placeholder para peticiones de trueque. | N/A | N/A |
+| Chats/ChatListScreen | Placeholder para listado de chats. | N/A | N/A |
+| Chat/ChatScreen | Chat simulado con conversaciones locales y envío de mensajes en memoria. | N/A | Estado local de componente |
+| Profile/ProfileScreen | Muestra datos del usuario y permite cerrar sesión. | N/A | `useAuthStore.user`, `useAuthStore.logout` |
+| Profile/ProfileMainScreen | Placeholder de perfil. | N/A | N/A |
+| Demo/DemoLandingScreen | Pantalla de demo de ofertas. | Navega a `DemoOffers`, `DemoOfferDetail` | Estado local |
+| Demo/DemoOffersScreen | Lista demo. | `DemoOfferDetail` | N/A |
+| Demo/DemoOfferDetailScreen | Detalle demo. | N/A | N/A |
+| Admin/AdminDashboardScreen | Placeholder de panel admin. | N/A | N/A |
+
+## Navegación
+- **Árbol**: `NavigationContainer` → `RootNavigator` (stack sin headers) →
+  - Si no hay usuario en `useAuthStore`: `AuthScreen`.
+  - Si hay usuario: `MainTabs` con pestañas `Trades`, `Chat`, `Profile`.
+- **Flujo típico**: usuario abre app → ve AuthScreen → login/registro (`/auth/login` o `/auth/register`) → stack cambia a `MainTabs` → pestaña `Trades` muestra trueques demo → desde `OffersListScreen` puede abrir `ContractPreviewScreen` y generar contrato (`/trueqia/contracts/preview`), simulando un trueque cerrado.
+
+## Estado global / stores (Zustand)
+- **`auth.store.ts`**: guarda `token`, `user`, y expone `login`, `register`, `logout`, `setAuth`.
+  - Backends: `apiPost` a `/auth/login` y `/auth/register`.
+- **`offers.store.ts`**: mantiene `items`, `loading`, `error`; acción `loadOffers` que usa `apiAuthGet` contra `/trueqia/offers`.
+- No hay stores para peticiones, órdenes ni chat; esas pantallas usan mocks/estado local.
+
+## Integración con la API
+- `AuthScreen`: `POST /auth/login`, `POST /auth/register`.
+- `OffersListScreen`: `GET /trueqia/offers` para cargar ofertas; botón navega a `ContractPreviewScreen`.
+- `ContractPreviewScreen`: `POST /trueqia/contracts/preview` con datos de solicitante/proveedor/tokens/notas para recibir `contractText`.
+- Resto de pantallas usan datos locales o están pendientes de conexión (`Requests`, `Chats`, `Admin`).
+
+## Problemas y observaciones
+- Varias pantallas duplicadas o placeholder (`LoginScreen`, `RegisterScreen`, `RequestsListScreen`, `ChatListScreen`, `AdminDashboardScreen`, componentes Demo) sin navegación real desde el flujo principal.
+- No hay manejo de expiración de token ni refresco; `apiAuthGet`/`apiAuthPost` solo leen token en memoria.
+- Ausencia de validaciones/formularios avanzados y sin manejo global de errores de red.
+- Falta sincronización real de chat, peticiones y órdenes; solo mocks.

--- a/trueqia/README.md
+++ b/trueqia/README.md
@@ -1,0 +1,6 @@
+# TRUEQIA (app móvil)
+
+Aplicación Expo/React Native orientada a trueques con autenticación JWT y navegación por pestañas (Trueques, Chat, Perfil).
+
+- **Arquitectura detallada**: consulta [docs/trueqia-architecture.md](../docs/trueqia-architecture.md).
+- **Backend asociado**: comparte endpoints con `/api/trueqia/*` del servicio Node (ver [docs/backend-architecture.md](../docs/backend-architecture.md)).


### PR DESCRIPTION
## Summary
- document architecture and flows for TrueQIA and Allwain mobile apps
- document backend stack, endpoints, and auth model
- link each project README to the new architecture guides

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f511286208326ace1f420cee1c4a5)