### PR TITLE
Update architecture docs and add radiography report

### DIFF
--- a/docs/allwain-architecture.md
+++ b/docs/allwain-architecture.md
@@ -1,51 +1,45 @@
 # Arquitectura de Allwain (mobile)
 
 ## Resumen funcional
-- **Qué es**: app móvil Expo/React Native enfocada en escaneo y búsqueda de productos/servicios con ofertas comisionadas. Comparte backend con TrueQIA pero con temática y UI diferente (paleta salmón).
-- **Diferencias clave**: flujo centrado en búsqueda y escaneo demo, invitados/compras con resultados sugeridos; sin trueques ni contratos.
+- **Qué es**: app móvil Expo/React Native enfocada en escaneo y búsqueda de productos/servicios con ofertas comisionadas. Comparte backend con TrueQIA pero con temática y UI propia en paleta salmón.
+- **Diferencias clave**: flujo centrado en búsqueda y escaneo demo (lector conectado a `/allwain/scan-demo`), invitados/compras con resultados sugeridos y consumo de ofertas reales vía `/allwain/offers`; no comparte estilos ni componentes de TrueQIA.
 
 ## Flujo principal de usuario
 1. Onboarding/Login en `AuthScreen` usando `/auth/register` o `/auth/login`.
 2. Pestañas principales (`MainTabs`):
-   - **Buscar**: entrada de texto y resultados sugeridos estáticos.
-   - **Ofertas**: listado demo de ofertas y comisión estimada.
+   - **Buscar**: entrada de texto y resultados sugeridos estáticos + accesos a escaneo y demo.
+   - **Ofertas**: listado conectado a `/allwain/offers` con loader, error y estado vacío.
    - **Perfil**: datos del usuario y cierre de sesión.
-3. Desde secciones de Scan/Guests/Demo se simulan flujos de invitaciones, escaneo QR/etiquetas y resultados de AI pricing.
+3. Flujo de escaneo conectado al backend: `ScanScreen` llama a `/allwain/scan-demo` y navega a `ScanResultScreen`; este último puede reutilizar el resultado recibido o recargarlo desde el backend.
+4. Flujos de invitados y demo AI pricing siguen siendo mocks pero mantienen la misma temática visual.
 
 ## Mapa de pantallas
 | Pantalla | Propósito | Navegación | Stores/Hooks |
 | --- | --- | --- | --- |
 | Auth/AuthScreen | Formulario de login/registro unificado. | Stack raíz decide `MainTabs` tras autenticación. | `useAuthStore.login`, `useAuthStore.register` |
-| Auth/LoginScreen / Auth/RegisterScreen | Placeholders. | N/A | N/A |
-| Search/SearchScreen | Búsqueda con resultados mock y CTA de mejor precio. | N/A | Estado local |
-| Deals/DealsScreen | Tarjetas de ofertas demo con comisión y CTA de invitar. | N/A | N/A |
-| Offers/OffersScreen | Placeholder de ofertas (puente para integración backend). | N/A | N/A |
-| Scan/HomeScreen | Landing de escaneo con CTA hacia flujo de cámara/resultado. | Puede ir a `ScanScreen` / `ScanResultScreen` | Estado local |
-| Scan/ScanScreen | Simulación de escaneo de QR/etiqueta. | `ScanResultScreen` | Estado local |
-| Scan/ScanResultScreen | Resultado demo de lectura con sugerencias. | N/A | N/A |
+| Search/SearchScreen | Búsqueda con resultados mock y CTA hacia escaneo y demo. | Navega a `Scan`, `DemoLanding`. | Estado local |
+| Deals/DealsScreen | Lista ofertas reales de `/allwain/offers` con loader/error y CTA a escaneo/invitados. | Navega a `Scan`, `Guests`. | `getAllwainOffers` |
+| Scan/ScanScreen | Dispara `/allwain/scan-demo` y envía resultado al detalle. | `ScanResultScreen` | `getAllwainScanDemo` |
+| Scan/ScanResultScreen | Muestra resultado del backend; puede recargar demo y gestiona expiración de token. | N/A | `getAllwainScanDemo` |
 | Guests/GuestsScreen | Gestión de invitados/comisiones demo. | N/A | N/A |
 | Profile/ProfileScreen | Perfil del usuario y logout. | N/A | `useAuthStore.logout` |
-| Profile/ProfileMainScreen | Placeholder de perfil extendido. | N/A | N/A |
-| Demo/DemoLandingScreen / DemoScanResultScreen | Flujos demo de AI pricing/escaneo. | N/A | Estado local |
-| Admin/AdminDashboardScreen | Placeholder. | N/A | N/A |
+| Demo/DemoLandingScreen / DemoScanResultScreen | Flujos demo de AI pricing/escaneo (mock). | N/A | Estado local |
+| Admin/AdminDashboardScreen | Placeholder no enlazado. | N/A | N/A |
 
 ## Navegación
-- **Árbol**: `RootNavigator` (stack) muestra `AuthScreen` si no hay `user`; tras login carga `MainTabs` con pestañas `Buscar`, `Ofertas`, `Perfil`.
-- **Flujo**: abrir app → autenticarse → navegar entre pestañas; flujos de escaneo/invitados están enlazados mediante botones internos desde `ScanHome`/`Deals`.
+- **Árbol**: `RootNavigator` (stack) muestra `AuthScreen` si no hay `user`; tras login carga `MainTabs` con pestañas `Buscar`, `Ofertas`, `Perfil` y habilita stack secundario para `Scan`, `ScanResult`, `Guests`, `DemoLanding`, `DemoScanResult`.
+- **Flujo**: abrir app → autenticarse → navegar entre pestañas; escaneo y demo se lanzan desde botones en `Search` o `Deals`.
 
 ## Estado global / stores
-- **`auth.store.ts`**: igual que TrueQIA; gestiona `token`, `user`, `login`, `register`, `logout` usando `apiPost` hacia `/auth/login` y `/auth/register`.
-- No hay otros stores: resultados de búsqueda, escaneo, invitados y ofertas se mantienen en mocks o estado local.
+- **`auth.store.ts`**: gestiona `token`, `user`, `login`, `register`, `logout` usando `apiPost` hacia `/auth/login` y `/auth/register`.
+- No hay otros stores: resultados de búsqueda, escaneo, invitados y ofertas se mantienen en estado local con llamadas directas a `getAllwainOffers`/`getAllwainScanDemo`.
 
 ## Integración con el backend
 - **Autenticación**: `POST /auth/register`, `POST /auth/login`.
-- **Rutas específicas** (implementadas pero aún no conectadas en UI principal):
-  - `GET /allwain/scan-demo`: resultado de lectura de etiqueta.
-  - `GET /allwain/offers`: ofertas asociadas a Allwain.
-- **Endpoints compartidos con TrueQIA**: `/auth/*`; el backend diferencia propietario en `/trueqia/offers` vs `/allwain/offers`.
+- **Rutas específicas**: `GET /allwain/scan-demo` (Scan y ScanResult) y `GET /allwain/offers` (Deals).
+- **Manejo de errores/expiración**: `apiAuthGet` invalida token ante 401 (`AUTH_EXPIRED`) y los `screen` muestran mensajes de error o estado vacío según corresponda.
 
 ## Inconsistencias / riesgos
-- Amplio uso de pantallas placeholder sin integración real.
-- No se consumen los endpoints `/allwain/scan-demo` ni `/allwain/offers` desde el código actual.
-- Falta manejo de errores de red y expiración de token; los datos de mock pueden divergir del backend.
-- Flujos de invitados y comisiones son únicamente estáticos; requiere modelado de datos real.
+- Varias pantallas siguen siendo placeholder (Admin, Offers antiguos) o mocks (Guests, demo AI pricing).
+- Búsqueda y flujos de invitados/comisiones no consumen backend.
+- No hay almacenamiento persistente del token; depende del estado en memoria para mantener la sesión.

--- a/docs/radiografia-a1-a5-t6-t7.md
+++ b/docs/radiografia-a1-a5-t6-t7.md
@@ -1,0 +1,35 @@
+# Radiografía tras tareas Allwain A1–A5 y TrueQIA T6–T7
+
+## Navegación y flujo
+- **Allwain**: `RootNavigator` conmuta entre `AuthScreen` y `MainTabs` (Buscar, Ofertas, Perfil). El stack adicional expone `Scan`, `ScanResult`, `Guests`, `DemoLanding`, `DemoScanResult`. Pantallas de Admin/Offers legacy no están enlazadas.
+- **TrueQIA**: `RootNavigator` alterna `AuthScreen` con tabs `Trades`, `Chat`, `Profile`. Requests, ChatList, ProfileMain, Admin y las pantallas demo siguen fuera del árbol de navegación actual.
+
+## Tema y estilos
+- La app Allwain aplica el tema salmón en contenedor de navegación, headers y fondos (`colors.salmon`, `colors.dark`) y no referencia estilos de TrueQIA, que mantiene su propia paleta azul (`config/theme.ts`). No hay imports cruzados de temas entre apps.
+
+## Consumo de API en Allwain
+- **Ofertas**: `DealsScreen` usa `getAllwainOffers` (`/api/allwain/offers`) con loader, mensaje de error y estado vacío. 
+- **Escaneo demo**: `ScanScreen` y `ScanResultScreen` consumen `/api/allwain/scan-demo`; permiten reintento y muestran errores de autenticación.
+
+## Loaders, errores y expiración de token
+- **Allwain**: `apiAuthGet` desloguea ante 401 (`AUTH_EXPIRED`) y las pantallas de ofertas/escaneo presentan loaders y mensajes de error específicos.
+- **TrueQIA**: las llamadas autenticadas (`apiAuthGet`/`apiAuthPost`) devuelven errores genéricos y no limpian sesión; `loadOffers` solo muestra error en memoria sin reintentos ni manejo de expiración de token.
+
+## Estado de Requests, Chats y Admin en TrueQIA
+- `RequestsListScreen` y `Chats/ChatListScreen` son placeholders sin integración ni acceso desde tabs.
+- `ChatScreen` muestra un módulo demo dentro de la pestaña `Chat` (estado local sin backend).
+- `AdminDashboardScreen` permanece como placeholder no navegable (quedó referenciado solo en código legado de perfil).
+
+## Pantallas huérfanas e imports cruzados
+- Pantallas huérfanas: Allwain (Admin, Offers legacy), TrueQIA (Login/Register placeholders, RequestsList, ChatList, ProfileMain, Admin y demos) no están conectadas al flujo principal. 
+- No se detectan imports cruzados innecesarios entre apps; cada una usa su propio espacio de nombres y colores.
+
+## Backend (seeds, endpoints, coherencia)
+- Seeds alineados en `data.store.ts` y `data/database.json`: usuario admin + 4 ofertas divididas por owner (TrueQIA vs Allwain) y 2 trades demo.
+- Endpoints activos según rutas: `/trueqia/offers`, `/trueqia/contracts/preview`, `/trueqia/trades`, `/allwain/offers`, `/allwain/scan-demo`, `/auth/*` y panel `/admin/*`. 
+- Las ofertas se filtran por `owner`, evitando mezclar datos entre aplicaciones; no hay refresco automático de cache si se edita el JSON manualmente.
+
+## Pendientes e inconsistencias
+- TrueQIA carece de manejo de expiración de token y reintentos; las pantallas Requests/Chats/Admin siguen sin conexión a backend.
+- Allwain mantiene secciones mock (Guests, demo AI) y carece de persistencia de sesión.
+- Siguen existiendo pantallas huérfanas heredadas en ambos proyectos que podrían depurarse o reinsertarse en la navegación.

--- a/docs/trueqia-architecture.md
+++ b/docs/trueqia-architecture.md
@@ -2,49 +2,46 @@
 
 ## Resumen funcional
 - **Qué es**: aplicación móvil Expo/React Native centrada en trueques y colaboración, con navegación por pestañas para trueques, chat y perfil.
-- **Capacidades de usuario**: registro e inicio de sesión con token JWT, exploración de trueques destacados (mock), visualización de ofertas provenientes del backend, generación de previsualizaciones de contrato IA, mensajería simulada dentro de la app y gestión básica de perfil/cierre de sesión.
+- **Capacidades de usuario**: registro/inicio de sesión con token JWT, exploración de trueques destacados (mock), visualización de ofertas provenientes del backend, generación de previsualizaciones de contrato IA, mensajería simulada y un panel de perfil con cierre de sesión.
 
 ## Mapa de pantallas (`src/screens`)
 
 | Pantalla | Propósito | Navega a | Stores/Hooks clave |
 | --- | --- | --- | --- |
-| Auth/AuthScreen | Registro/Login unificados con manejo de errores y loaders. | Con stack raíz decide redirección a `MainTabs` tras login. | `useAuthStore.login`, `useAuthStore.register` |
-| Auth/LoginScreen | Placeholder de login (no conectado). | N/A | N/A |
-| Auth/RegisterScreen | Placeholder de registro. | N/A | N/A |
+| Auth/AuthScreen | Registro/Login unificados con manejo de errores y loaders. | Stack raíz decide redirección a `MainTabs` tras login. | `useAuthStore.login`, `useAuthStore.register` |
+| Auth/LoginScreen / Auth/RegisterScreen | Placeholders no usados en navegación actual. | N/A | N/A |
 | Home/HomeScreen | Mensaje de bienvenida con datos del usuario. | N/A | `useAuthStore.user` |
-| Trades/TradesScreen | Lista mock de trueques destacados. | N/A | N/A |
+| Trades/TradesScreen | Lista mock de trueques destacados (pestaña inicial). | N/A | N/A |
 | Offers/OffersListScreen | Consume backend para listar ofertas y abrir previsualización de contrato. | `ContractPreview` | `useOffersStore` |
 | Contracts/ContractPreviewScreen | Genera contrato demo llamando al backend con datos de oferta/usuarios. | N/A | `apiAuthPost` |
-| Requests/RequestsListScreen | Placeholder para peticiones de trueque. | N/A | N/A |
-| Chats/ChatListScreen | Placeholder para listado de chats. | N/A | N/A |
-| Chat/ChatScreen | Chat simulado con conversaciones locales y envío de mensajes en memoria. | N/A | Estado local de componente |
-| Profile/ProfileScreen | Muestra datos del usuario y permite cerrar sesión. | N/A | `useAuthStore.user`, `useAuthStore.logout` |
-| Profile/ProfileMainScreen | Placeholder de perfil. | N/A | N/A |
-| Demo/DemoLandingScreen | Pantalla de demo de ofertas. | Navega a `DemoOffers`, `DemoOfferDetail` | Estado local |
+| Requests/RequestsListScreen | Placeholder sin navegación desde tabs. | N/A | N/A |
+| Chats/ChatListScreen | Placeholder sin navegación desde tabs. | N/A | N/A |
+| Chat/ChatScreen | Chat simulado con conversaciones locales y envío de mensajes en memoria (pestaña `Chat`). | N/A | Estado local de componente |
+| Profile/ProfileScreen | Muestra datos del usuario y permite cerrar sesión (pestaña `Profile`). | N/A | `useAuthStore.user`, `useAuthStore.logout` |
+| Profile/ProfileMainScreen | Placeholder no enlazado; versión antigua del perfil/admin. | N/A | N/A |
+| Demo/DemoLandingScreen | Pantalla de demo de ofertas. | `DemoOffers`, `DemoOfferDetail` | Estado local |
 | Demo/DemoOffersScreen | Lista demo. | `DemoOfferDetail` | N/A |
 | Demo/DemoOfferDetailScreen | Detalle demo. | N/A | N/A |
-| Admin/AdminDashboardScreen | Placeholder de panel admin. | N/A | N/A |
+| Admin/AdminDashboardScreen | Placeholder sin acceso desde navegación actual. | N/A | N/A |
 
 ## Navegación
-- **Árbol**: `NavigationContainer` → `RootNavigator` (stack sin headers) →
-  - Si no hay usuario en `useAuthStore`: `AuthScreen`.
-  - Si hay usuario: `MainTabs` con pestañas `Trades`, `Chat`, `Profile`.
-- **Flujo típico**: usuario abre app → ve AuthScreen → login/registro (`/auth/login` o `/auth/register`) → stack cambia a `MainTabs` → pestaña `Trades` muestra trueques demo → desde `OffersListScreen` puede abrir `ContractPreviewScreen` y generar contrato (`/trueqia/contracts/preview`), simulando un trueque cerrado.
+- **Árbol**: `NavigationContainer` → `RootNavigator` (stack sin headers) → si no hay usuario `AuthScreen`; si existe, `MainTabs` con pestañas `Trades`, `Chat`, `Profile`.
+- **Flujo típico**: usuario abre app → se autentica (`/auth/login` o `/auth/register`) → stack cambia a `MainTabs` → pestaña `Trades` muestra trueques demo → ofertas/contratos accesibles desde rutas internas (no hay enlaces visibles en tabs); chat y perfil usan datos locales.
+- **Pantallas fuera del flujo**: Requests, ChatList, ProfileMain, Admin y demos no están enlazadas en la navegación principal tras la refactorización a tabs.
 
 ## Estado global / stores (Zustand)
-- **`auth.store.ts`**: guarda `token`, `user`, y expone `login`, `register`, `logout`, `setAuth`.
-  - Backends: `apiPost` a `/auth/login` y `/auth/register`.
-- **`offers.store.ts`**: mantiene `items`, `loading`, `error`; acción `loadOffers` que usa `apiAuthGet` contra `/trueqia/offers`.
-- No hay stores para peticiones, órdenes ni chat; esas pantallas usan mocks/estado local.
+- **`auth.store.ts`**: guarda `token`, `user`, expone `login`, `register`, `logout`, `setAuth`. Persistencia solo en memoria.
+- **`offers.store.ts`**: mantiene `items`, `loading`, `error`; acción `loadOffers` usa `apiAuthGet` contra `/trueqia/offers`.
+- No hay stores para peticiones ni chat; pantallas correspondientes son mock/estado local.
 
 ## Integración con la API
 - `AuthScreen`: `POST /auth/login`, `POST /auth/register`.
-- `OffersListScreen`: `GET /trueqia/offers` para cargar ofertas; botón navega a `ContractPreviewScreen`.
-- `ContractPreviewScreen`: `POST /trueqia/contracts/preview` con datos de solicitante/proveedor/tokens/notas para recibir `contractText`.
-- Resto de pantallas usan datos locales o están pendientes de conexión (`Requests`, `Chats`, `Admin`).
+- `OffersListScreen`: `GET /trueqia/offers` con loader/error y sin reintento automático.
+- `ContractPreviewScreen`: `POST /trueqia/contracts/preview` con datos de oferta/usuarios para recibir `contractText`.
+- `TradesScreen`, `RequestsListScreen`, `ChatListScreen`, `AdminDashboardScreen` y demos siguen desconectados del backend.
 
 ## Problemas y observaciones
-- Varias pantallas duplicadas o placeholder (`LoginScreen`, `RegisterScreen`, `RequestsListScreen`, `ChatListScreen`, `AdminDashboardScreen`, componentes Demo) sin navegación real desde el flujo principal.
-- No hay manejo de expiración de token ni refresco; `apiAuthGet`/`apiAuthPost` solo leen token en memoria.
+- Varias pantallas duplicadas o placeholder (Login/Register heredadas, RequestsList, ChatList, ProfileMain, AdminDashboard, demos) sin navegación real desde el flujo principal.
+- No hay manejo explícito de expiración de token en `apiAuthGet`/`apiAuthPost`; los fallos de auth devuelven errores genéricos y no limpian sesión.
 - Ausencia de validaciones/formularios avanzados y sin manejo global de errores de red.
-- Falta sincronización real de chat, peticiones y órdenes; solo mocks.
+- Chat y peticiones siguen siendo mocks sin sincronización backend.


### PR DESCRIPTION
## Summary
- refresh Allwain architecture notes with current navigation, API consumption, and error handling details
- update TrueQIA and backend architecture docs to reflect present flows, seeds, and endpoints
- add a comprehensive radiografía documenting the state after Allwain A1–A5 and TrueQIA T6–T7

## Testing
- not run (documentation-only changes)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f5965593c83268dd6756fd5c875b5)