### PR TITLE
Add session persistence and refresh demo flows

### DIFF
--- a/allwain/package.json
+++ b/allwain/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@react-native-async-storage/async-storage": "^1.23.1",
     "@react-navigation/bottom-tabs": "^6.5.20",
     "@react-navigation/native": "^6.1.17",
     "@react-navigation/native-stack": "^6.9.26",

--- a/allwain/src/config/api.ts
+++ b/allwain/src/config/api.ts
@@ -23,8 +23,10 @@ async function parseResponse(res: Response) {
 
 function handleAuthError(status: number) {
   if (status === 401) {
-    useAuthStore.getState().logout();
-    throw new Error("AUTH_EXPIRED");
+    useAuthStore
+      .getState()
+      .logout("Sesión expirada, vuelve a iniciar sesión.");
+    throw new Error("SESSION_EXPIRED");
   }
 }
 
@@ -40,7 +42,7 @@ export async function apiPost<T>(path: string, body: unknown): Promise<T> {
   const data = await parseResponse(res);
 
   if (!res.ok) {
-    throw new Error(data?.error || `API_ERROR_${res.status}`);
+    throw new Error(data?.message || data?.error || `API_ERROR_${res.status}`);
   }
 
   return data as T;
@@ -62,7 +64,7 @@ export async function apiAuthGet<T>(path: string): Promise<T> {
 
   if (!res.ok) {
     handleAuthError(res.status);
-    throw new Error(data?.error || `API_ERROR_${res.status}`);
+    throw new Error(data?.message || data?.error || `API_ERROR_${res.status}`);
   }
 
   return data as T;

--- a/allwain/src/navigation/RootNavigator.tsx
+++ b/allwain/src/navigation/RootNavigator.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useAuthStore } from "../store/auth.store";
 import AuthScreen from "../screens/Auth/AuthScreen";
@@ -9,6 +9,7 @@ import GuestsScreen from "../screens/Guests/GuestsScreen";
 import DemoLandingScreen from "../screens/Demo/DemoLandingScreen";
 import DemoScanResultScreen from "../screens/Demo/DemoScanResultScreen";
 import { colors } from "../theme/colors";
+import { ActivityIndicator, View } from "react-native";
 
 const Stack = createNativeStackNavigator();
 
@@ -34,7 +35,23 @@ function AppNavigator() {
 
 export default function RootNavigator() {
   const user = useAuthStore((s) => s.user);
+  const hydrated = useAuthStore((s) => s.hydrated);
+  const restoreSession = useAuthStore((s) => s.restoreSession);
   const isLogged = Boolean(user);
+
+  useEffect(() => {
+    if (!hydrated) {
+      restoreSession();
+    }
+  }, [hydrated, restoreSession]);
+
+  if (!hydrated) {
+    return (
+      <View style={{ flex: 1, justifyContent: "center", alignItems: "center", backgroundColor: colors.salmon }}>
+        <ActivityIndicator color={colors.dark} />
+      </View>
+    );
+  }
 
   return (
     <Stack.Navigator screenOptions={{ headerShown: false }}>

--- a/allwain/src/screens/Auth/AuthScreen.tsx
+++ b/allwain/src/screens/Auth/AuthScreen.tsx
@@ -20,6 +20,15 @@ export default function AuthScreen() {
 
   const login = useAuthStore((s) => s.login);
   const register = useAuthStore((s) => s.register);
+  const sessionMessage = useAuthStore((s) => s.sessionMessage);
+  const clearSessionMessage = useAuthStore((s) => s.clearSessionMessage);
+
+  React.useEffect(() => {
+    if (sessionMessage) {
+      setError(sessionMessage);
+      clearSessionMessage();
+    }
+  }, [sessionMessage, clearSessionMessage]);
 
   async function handleAuth(action: "login" | "register") {
     if (!email || !password || (action === "register" && !name)) {
@@ -43,7 +52,7 @@ export default function AuthScreen() {
         setError("El email ya está registrado");
       } else if (err?.message === "MISSING_FIELDS") {
         setError("Faltan datos para continuar");
-      } else if (err?.message === "AUTH_EXPIRED") {
+      } else if (err?.message === "SESSION_EXPIRED") {
         setError("Sesión expirada, vuelve a entrar");
       } else {
         setError("No se pudo procesar la solicitud");

--- a/allwain/src/screens/Deals/DealsScreen.tsx
+++ b/allwain/src/screens/Deals/DealsScreen.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { ScrollView, Text, StyleSheet, TouchableOpacity, ActivityIndicator, View } from "react-native";
 import { getAllwainOffers, Offer } from "../../api/allwain.api";
 import { colors } from "../../theme/colors";
+import { useFocusEffect } from "@react-navigation/native";
 
 export default function DealsScreen({ navigation }: any) {
   const [offers, setOffers] = useState<Offer[]>([]);
@@ -15,7 +16,7 @@ export default function DealsScreen({ navigation }: any) {
       const data = await getAllwainOffers();
       setOffers(data);
     } catch (err: any) {
-      if (err?.message === "AUTH_EXPIRED") {
+      if (err?.message === "SESSION_EXPIRED") {
         setError("Sesión expirada. Vuelve a iniciar sesión.");
       } else {
         setError("No se pudieron cargar las ofertas.");
@@ -28,6 +29,12 @@ export default function DealsScreen({ navigation }: any) {
   useEffect(() => {
     loadOffers();
   }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      loadOffers();
+    }, [])
+  );
 
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.content}>

--- a/allwain/src/screens/Profile/ProfileMainScreen.tsx
+++ b/allwain/src/screens/Profile/ProfileMainScreen.tsx
@@ -5,10 +5,10 @@ import { colors } from "../../theme/colors";
 
 export default function ProfileMainScreen({ navigation }: any) {
   const user = useAuthStore((s) => s.user);
-  const clearAuth = useAuthStore((s) => s.clearAuth);
+  const logout = useAuthStore((s) => s.logout);
 
-  function logout() {
-    clearAuth();
+  async function handleLogout() {
+    await logout();
     navigation.replace("Login");
   }
 
@@ -30,7 +30,7 @@ export default function ProfileMainScreen({ navigation }: any) {
         </>
       )}
 
-      <TouchableOpacity style={[styles.secondaryButton, { marginTop: 12 }]} onPress={logout} activeOpacity={0.9}>
+      <TouchableOpacity style={[styles.secondaryButton, { marginTop: 12 }]} onPress={handleLogout} activeOpacity={0.9}>
         <Text style={styles.secondaryButtonText}>Cerrar sesión</Text>
       </TouchableOpacity>
     </View>

--- a/allwain/src/screens/Profile/ProfileScreen.tsx
+++ b/allwain/src/screens/Profile/ProfileScreen.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { View, Text, StyleSheet, TouchableOpacity, Alert, ScrollView } from "react-native";
+import React, { useState } from "react";
+import { View, Text, StyleSheet, TouchableOpacity, Alert, ScrollView, ActivityIndicator } from "react-native";
 import { useNavigation } from "@react-navigation/native";
 import { useAuthStore } from "../../store/auth.store";
 import { colors } from "../../theme/colors";
@@ -8,12 +8,19 @@ export default function ProfileScreen() {
   const user = useAuthStore((s) => s.user);
   const logout = useAuthStore((s) => s.logout);
   const navigation = useNavigation<any>();
+  const [loading, setLoading] = useState(false);
 
   const displayUser =
     user || ({ name: "Allwain User", email: "demo@allwain.com", role: "Comprador" } as const);
 
   function handleEdit() {
     Alert.alert("Función en desarrollo", "Editar perfil estará disponible pronto.");
+  }
+
+  async function handleLogout() {
+    setLoading(true);
+    await logout();
+    setLoading(false);
   }
 
   return (
@@ -45,8 +52,17 @@ export default function ProfileScreen() {
         <Text style={styles.secondaryButtonText}>Invitados y comisiones</Text>
       </TouchableOpacity>
 
-      <TouchableOpacity style={styles.logoutButton} onPress={logout} activeOpacity={0.9}>
-        <Text style={styles.logoutText}>Cerrar sesión</Text>
+      <TouchableOpacity
+        style={[styles.logoutButton, loading && { opacity: 0.7 }]}
+        onPress={handleLogout}
+        activeOpacity={0.9}
+        disabled={loading}
+      >
+        {loading ? (
+          <ActivityIndicator color={colors.white} />
+        ) : (
+          <Text style={styles.logoutText}>Cerrar sesión</Text>
+        )}
       </TouchableOpacity>
     </ScrollView>
   );

--- a/allwain/src/screens/Scan/ScanResultScreen.tsx
+++ b/allwain/src/screens/Scan/ScanResultScreen.tsx
@@ -21,7 +21,7 @@ export default function ScanResultScreen({ navigation, route }: ScanResultProps)
       const res = await getAllwainScanDemo();
       setData(res);
     } catch (err: any) {
-      if (err?.message === "AUTH_EXPIRED") {
+      if (err?.message === "SESSION_EXPIRED") {
         setError("Sesión expirada. Inicia sesión de nuevo.");
       } else {
         setError("No se ha podido completar el escaneo.");

--- a/allwain/src/screens/Scan/ScanScreen.tsx
+++ b/allwain/src/screens/Scan/ScanScreen.tsx
@@ -14,7 +14,7 @@ export default function ScanScreen({ navigation }: any) {
       const result = await getAllwainScanDemo();
       navigation.navigate("ScanResult", { result });
     } catch (err: any) {
-      if (err?.message === "AUTH_EXPIRED") {
+      if (err?.message === "SESSION_EXPIRED") {
         setError("Tu sesión ha expirado. Vuelve a iniciar sesión.");
       } else {
         setError("No se ha podido completar el escaneo.");

--- a/allwain/src/store/auth.store.ts
+++ b/allwain/src/store/auth.store.ts
@@ -1,3 +1,4 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { create } from "zustand";
 import { apiPost, AuthResponse } from "../config/api";
 
@@ -11,27 +12,61 @@ export type User = {
 interface AuthState {
   token: string | null;
   user: User | null;
+  hydrated: boolean;
+  sessionMessage: string | null;
   setAuth: (payload: AuthResponse) => void;
   clearAuth: () => void;
+  restoreSession: () => Promise<void>;
   login: (email: string, password: string) => Promise<AuthResponse>;
   register: (name: string, email: string, password: string) => Promise<AuthResponse>;
-  logout: () => void;
+  logout: (message?: string) => Promise<void>;
+  clearSessionMessage: () => void;
+}
+
+const STORAGE_KEY = "allwain_auth";
+
+async function persistAuth(token: string, user: User) {
+  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify({ token, user }));
+}
+
+async function clearPersistedAuth() {
+  await AsyncStorage.removeItem(STORAGE_KEY);
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
   token: null,
   user: null,
+  hydrated: false,
+  sessionMessage: null,
   setAuth: ({ token, user }) => set({ token, user }),
   clearAuth: () => set({ token: null, user: null }),
+  restoreSession: async () => {
+    try {
+      const raw = await AsyncStorage.getItem(STORAGE_KEY);
+      if (!raw) return;
+      const parsed = JSON.parse(raw);
+      if (parsed?.token && parsed?.user) {
+        set({ token: parsed.token, user: parsed.user });
+      }
+    } finally {
+      set({ hydrated: true });
+    }
+  },
   login: async (email, password) => {
     const result = await apiPost<AuthResponse>("/auth/login", { email, password });
-    set({ token: result.token, user: result.user });
+    await persistAuth(result.token, result.user);
+    set({ token: result.token, user: result.user, sessionMessage: null });
     return result;
   },
   register: async (name, email, password) => {
     const result = await apiPost<AuthResponse>("/auth/register", { name, email, password });
-    set({ token: result.token, user: result.user });
+    await persistAuth(result.token, result.user);
+    set({ token: result.token, user: result.user, sessionMessage: null });
     return result;
   },
-  logout: () => set({ token: null, user: null }),
+  logout: async (message) => {
+    await clearPersistedAuth();
+    set({ token: null, user: null, sessionMessage: message ?? null });
+  },
+  clearSessionMessage: () => set({ sessionMessage: null }),
 }));

--- a/backend/src/middleware/auth.middleware.ts
+++ b/backend/src/middleware/auth.middleware.ts
@@ -9,7 +9,10 @@ export interface AuthRequest extends Request {
 
 export function authRequired(req: AuthRequest, res: Response, next: NextFunction) {
   const header = req.headers.authorization;
-  if (!header || !header.startsWith("Bearer ")) return res.status(401).json({ error: "UNAUTHORIZED" });
+  if (!header || !header.startsWith("Bearer "))
+    return res
+      .status(401)
+      .json({ code: "UNAUTHORIZED", message: "Token requerido" });
 
   const token = header.slice(7);
   try {
@@ -17,11 +20,14 @@ export function authRequired(req: AuthRequest, res: Response, next: NextFunction
     req.user = { id: payload.sub, email: payload.email, role: payload.role };
     next();
   } catch {
-    return res.status(401).json({ error: "INVALID_TOKEN" });
+    return res
+      .status(401)
+      .json({ code: "INVALID_TOKEN", message: "Sesión expirada o inválida" });
   }
 }
 
 export function adminOnly(req: AuthRequest, res: Response, next: NextFunction) {
-  if (!req.user || req.user.role !== "admin") return res.status(403).json({ error: "FORBIDDEN" });
+  if (!req.user || req.user.role !== "admin")
+    return res.status(403).json({ code: "FORBIDDEN", message: "Solo admin" });
   next();
 }

--- a/backend/src/services/data.store.ts
+++ b/backend/src/services/data.store.ts
@@ -87,6 +87,18 @@ function ensureDataDir() {
   }
 }
 
+function ensureDefaultAdmin(users: User[]): User[] {
+  const hasAdmin = users.some((u) => u.email === defaultData.users[0].email);
+  return hasAdmin ? users : [...users, { ...defaultData.users[0] }];
+}
+
+function mergeDefaultOffers(offers: Offer[]): Offer[] {
+  const missingDefaults = defaultData.offers.filter(
+    (defaultOffer) => !offers.some((offer) => offer.id === defaultOffer.id)
+  );
+  return [...offers, ...missingDefaults];
+}
+
 function loadFromDisk(): Database {
   ensureDataDir();
   if (!fs.existsSync(DATA_FILE)) {
@@ -99,8 +111,8 @@ function loadFromDisk(): Database {
 
   const parsed = JSON.parse(raw) as Database;
   return {
-    users: parsed.users || [],
-    offers: parsed.offers || defaultData.offers,
+    users: ensureDefaultAdmin(parsed.users || []),
+    offers: mergeDefaultOffers(parsed.offers || defaultData.offers),
     trades: parsed.trades || defaultData.trades,
   };
 }
@@ -124,8 +136,8 @@ export function persistDatabase() {
 
 export function resetDatabase(data: Partial<Database>) {
   cache = {
-    users: data.users ?? [],
-    offers: data.offers ?? defaultData.offers,
+    users: ensureDefaultAdmin(data.users ?? []),
+    offers: mergeDefaultOffers(data.offers ?? defaultData.offers),
     trades: data.trades ?? defaultData.trades,
   };
   persistDatabase();

--- a/docs/backend-architecture.md
+++ b/docs/backend-architecture.md
@@ -19,7 +19,7 @@
   - **Trade**: `id`, `title`, `status`, `participants`, `tokens`.
 - **Relaciones**: usuarios asociados a roles; ofertas se filtran por `owner`; trades contienen correos participantes. Persistencia en arrays (sin BD relacional).
 - **Almacenamiento** (`data.store.ts`):
-  - Lee/escribe JSON, inicializa ofertas y trades demo y crea el usuario admin.
+  - Lee/escribe JSON, inicializa ofertas y trades demo y asegura que siempre exista el usuario admin + 4 ofertas base (si faltan en el JSON se reinyectan).
   - Operaciones: `getDatabase`, `persistDatabase`, `resetDatabase`, `upsertUser`, `setUsers`, `getOffersForOwner`, `getTrades`.
 
 ## Tabla de endpoints (prefijo `/api`)
@@ -39,12 +39,12 @@
 | GET | /admin/ai/activity | Lista de eventos demo de moderación. | – | Bearer (admin) |
 
 ### Consumo por apps
-- **TrueQIA**: usa `/auth/register`, `/auth/login`, `/trueqia/offers`, `/trueqia/contracts/preview` (trades aún no conectados en UI), `/auth/me` disponible.
+- **TrueQIA**: usa `/auth/register`, `/auth/login`, `/trueqia/offers`, `/trueqia/contracts/preview`, `/trueqia/trades` y `/auth/me`.
 - **Allwain**: usa `/auth/register`, `/auth/login`, `/allwain/scan-demo` (flujo de escaneo) y `/allwain/offers` (pestaña Ofertas).
 
 ## Autenticación y roles
-- Middleware `authRequired`: valida header `Authorization: Bearer <token>`, usa `jwt.verify` con `ENV.JWT_SECRET`; si es válido adjunta `{id,email,role}` en `req.user`.
-- Middleware `adminOnly`: requiere `req.user.role === "admin"`; responde 403 en caso contrario.
+- Middleware `authRequired`: valida header `Authorization: Bearer <token>`, usa `jwt.verify` con `ENV.JWT_SECRET`; si es válido adjunta `{id,email,role}` en `req.user`. Respuestas de error consistentes: `{ code, message }` para 401 y 403.
+- Middleware `adminOnly`: requiere `req.user.role === "admin"`; responde 403 en caso contrario con `{ code, message }`.
 - Tokens se firman a 7 días (`registerUser`/`loginUser`) y contienen `sub`, `email`, `role`.
 - Roles permitidos en registro: `user`, `company`, `admin`, `buyer` (fallback a `user`).
 

--- a/trueqia/package.json
+++ b/trueqia/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@react-native-async-storage/async-storage": "^1.23.1",
     "@react-navigation/bottom-tabs": "^6.5.20",
     "@react-navigation/native": "^6.1.17",
     "@react-navigation/native-stack": "^6.9.26",

--- a/trueqia/src/config/api.ts
+++ b/trueqia/src/config/api.ts
@@ -13,6 +13,15 @@ export interface AuthResponse {
 
 import { useAuthStore } from "../store/auth.store";
 
+function handleUnauthorized(status: number, message?: string) {
+  if (status === 401) {
+    useAuthStore
+      .getState()
+      .logout(message || "Sesión expirada, vuelve a iniciar sesión.");
+    throw new Error("SESSION_EXPIRED");
+  }
+}
+
 export async function apiPost<T>(path: string, body: unknown): Promise<T> {
   const url = `${API_BASE_URL}${path}`;
 
@@ -28,7 +37,8 @@ export async function apiPost<T>(path: string, body: unknown): Promise<T> {
   } catch {}
 
   if (!res.ok) {
-    throw new Error(data?.error || `API_ERROR_${res.status}`);
+    handleUnauthorized(res.status, data?.message || data?.error);
+    throw new Error(data?.message || data?.error || `API_ERROR_${res.status}`);
   }
 
   return data as T;
@@ -52,7 +62,8 @@ export async function apiAuthGet<T>(path: string): Promise<T> {
   } catch {}
 
   if (!res.ok) {
-    throw new Error(data?.error || `API_ERROR_${res.status}`);
+    handleUnauthorized(res.status, data?.message || data?.error);
+    throw new Error(data?.message || data?.error || `API_ERROR_${res.status}`);
   }
 
   return data as T;
@@ -77,7 +88,8 @@ export async function apiAuthPost<T>(path: string, body: unknown): Promise<T> {
   } catch {}
 
   if (!res.ok) {
-    throw new Error(data?.error || `API_ERROR_${res.status}`);
+    handleUnauthorized(res.status, data?.message || data?.error);
+    throw new Error(data?.message || data?.error || `API_ERROR_${res.status}`);
   }
 
   return data as T;

--- a/trueqia/src/navigation/RootNavigator.tsx
+++ b/trueqia/src/navigation/RootNavigator.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
+import { ActivityIndicator, View } from "react-native";
 import AuthScreen from "../screens/Auth/AuthScreen";
 import MainTabs from "./MainTabs";
 import { useAuthStore } from "../store/auth.store";
@@ -9,6 +10,24 @@ const Stack = createNativeStackNavigator();
 
 export default function RootNavigator() {
   const user = useAuthStore((s) => s.user);
+  const hydrated = useAuthStore((s) => s.hydrated);
+  const restoreSession = useAuthStore((s) => s.restoreSession);
+
+  useEffect(() => {
+    if (!hydrated) {
+      restoreSession();
+    }
+  }, [hydrated, restoreSession]);
+
+  if (!hydrated) {
+    return (
+      <GestureHandlerRootView style={{ flex: 1 }}>
+        <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
+          <ActivityIndicator />
+        </View>
+      </GestureHandlerRootView>
+    );
+  }
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>

--- a/trueqia/src/screens/Auth/AuthScreen.tsx
+++ b/trueqia/src/screens/Auth/AuthScreen.tsx
@@ -16,12 +16,21 @@ import { useAuthStore } from "../../store/auth.store";
 export default function AuthScreen() {
   const login = useAuthStore((s) => s.login);
   const register = useAuthStore((s) => s.register);
+  const sessionMessage = useAuthStore((s) => s.sessionMessage);
+  const clearSessionMessage = useAuthStore((s) => s.clearSessionMessage);
 
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+
+  React.useEffect(() => {
+    if (sessionMessage) {
+      setError(sessionMessage);
+      clearSessionMessage();
+    }
+  }, [sessionMessage, clearSessionMessage]);
 
   const handleAuth = async (mode: "login" | "register") => {
     if (!email || !password || (mode === "register" && !name)) {

--- a/trueqia/src/screens/Offers/OffersListScreen.tsx
+++ b/trueqia/src/screens/Offers/OffersListScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useCallback } from "react";
 import {
   View,
   Text,
@@ -7,6 +7,7 @@ import {
   FlatList,
   StyleSheet,
 } from "react-native";
+import { useFocusEffect } from "@react-navigation/native";
 import { useOffersStore } from "../../store/offers.store";
 
 export default function OffersListScreen({ navigation }: any) {
@@ -15,9 +16,11 @@ export default function OffersListScreen({ navigation }: any) {
   const error = useOffersStore((s) => s.error);
   const loadOffers = useOffersStore((s) => s.loadOffers);
 
-  useEffect(() => {
-    loadOffers();
-  }, [loadOffers]);
+  useFocusEffect(
+    useCallback(() => {
+      loadOffers();
+    }, [loadOffers])
+  );
 
   return (
     <View style={{ flex: 1, padding: 24 }}>
@@ -33,8 +36,11 @@ export default function OffersListScreen({ navigation }: any) {
       {error && (
         <View style={styles.statusBox}>
           <Text style={[styles.statusText, { color: "#C1121F" }]}>
-            No pudimos cargar las ofertas: {error}
+            {error === "SESSION_EXPIRED"
+              ? "Sesión expirada, vuelve a iniciar sesión."
+              : `No pudimos cargar las ofertas: ${error}`}
           </Text>
+          <Button title="Reintentar" onPress={loadOffers} />
         </View>
       )}
 

--- a/trueqia/src/screens/Profile/ProfileMainScreen.tsx
+++ b/trueqia/src/screens/Profile/ProfileMainScreen.tsx
@@ -4,10 +4,10 @@ import { useAuthStore } from "../../store/auth.store";
 
 export default function ProfileMainScreen({ navigation }: any) {
   const user = useAuthStore((s) => s.user);
-  const clearAuth = useAuthStore((s) => s.clearAuth);
+  const logout = useAuthStore((s) => s.logout);
 
-  function logout() {
-    clearAuth();
+  async function handleLogout() {
+    await logout();
     navigation.replace("Login");
   }
 
@@ -28,7 +28,7 @@ export default function ProfileMainScreen({ navigation }: any) {
       )}
 
       <View style={{ height: 12 }} />
-      <Button title="Cerrar sesión" onPress={logout} />
+      <Button title="Cerrar sesión" onPress={handleLogout} />
     </View>
   );
 }

--- a/trueqia/src/screens/Profile/ProfileScreen.tsx
+++ b/trueqia/src/screens/Profile/ProfileScreen.tsx
@@ -1,17 +1,24 @@
-import React from "react";
-import { View, Text, StyleSheet, TouchableOpacity, Alert } from "react-native";
+import React, { useState } from "react";
+import { View, Text, StyleSheet, TouchableOpacity, Alert, ActivityIndicator } from "react-native";
 import { colors } from "../../config/theme";
 import { useAuthStore } from "../../store/auth.store";
 
 export default function ProfileScreen() {
   const user = useAuthStore((s) => s.user);
   const logout = useAuthStore((s) => s.logout);
+  const [loading, setLoading] = useState(false);
 
   const profile = {
     name: user?.name ?? "Usuario TRUEQIA",
     email: user?.email ?? "usuario@trueqia.com",
-    location: "Valencia, España",
+    role: user?.role ?? "colaborador",
   };
+
+  async function handleLogout() {
+    setLoading(true);
+    await logout();
+    setLoading(false);
+  }
 
   return (
     <View style={styles.container}>
@@ -24,8 +31,8 @@ export default function ProfileScreen() {
         <Text style={styles.label}>Email</Text>
         <Text style={styles.value}>{profile.email}</Text>
 
-        <Text style={styles.label}>Ubicación</Text>
-        <Text style={styles.value}>{profile.location}</Text>
+        <Text style={styles.label}>Rol</Text>
+        <Text style={styles.value}>{profile.role}</Text>
       </View>
 
       <TouchableOpacity
@@ -35,8 +42,12 @@ export default function ProfileScreen() {
         <Text style={styles.secondaryText}>Editar (mock)</Text>
       </TouchableOpacity>
 
-      <TouchableOpacity style={styles.button} onPress={logout}>
-        <Text style={styles.buttonText}>Cerrar sesión</Text>
+      <TouchableOpacity style={styles.button} onPress={handleLogout} disabled={loading}>
+        {loading ? (
+          <ActivityIndicator color="#FFF" />
+        ) : (
+          <Text style={styles.buttonText}>Cerrar sesión</Text>
+        )}
       </TouchableOpacity>
     </View>
   );

--- a/trueqia/src/screens/Trades/TradesScreen.tsx
+++ b/trueqia/src/screens/Trades/TradesScreen.tsx
@@ -1,50 +1,65 @@
-import React from "react";
-import { View, Text, FlatList, StyleSheet } from "react-native";
+import React, { useEffect } from "react";
+import { View, Text, FlatList, StyleSheet, TouchableOpacity, ActivityIndicator } from "react-native";
 import { colors } from "../../config/theme";
-
-type Trade = {
-  id: string;
-  title: string;
-  description: string;
-  tokens: number;
-};
-
-const trades: Trade[] = [
-  {
-    id: "1",
-    title: "Clases de guitarra",
-    description: "Intercambio por clases de inglés",
-    tokens: 25,
-  },
-  {
-    id: "2",
-    title: "Diseño de logo",
-    description: "Busco consultoría de marketing",
-    tokens: 40,
-  },
-  {
-    id: "3",
-    title: "Sesión de fotos",
-    description: "Trueque por edición de video",
-    tokens: 32,
-  },
-];
+import { useTradesStore } from "../../store/trades.store";
 
 export default function TradesScreen() {
+  const items = useTradesStore((s) => s.items);
+  const loading = useTradesStore((s) => s.loading);
+  const error = useTradesStore((s) => s.error);
+  const loadTrades = useTradesStore((s) => s.loadTrades);
+
+  useEffect(() => {
+    loadTrades();
+  }, [loadTrades]);
+
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Trueques destacados</Text>
+      <Text style={styles.title}>Trueques activos</Text>
+
+      {loading && (
+        <View style={styles.statusBox}>
+          <ActivityIndicator color={colors.primary} />
+          <Text style={styles.statusText}>Cargando trueques…</Text>
+        </View>
+      )}
+
+      {error && (
+        <View style={styles.statusBox}>
+          <Text style={[styles.statusText, { color: "#B3261E" }]}>
+            {error === "SESSION_EXPIRED"
+              ? "Sesión expirada, vuelve a iniciar sesión."
+              : "No pudimos cargar los trueques."}
+          </Text>
+          <TouchableOpacity onPress={loadTrades} style={styles.retryButton}>
+            <Text style={styles.retryText}>Reintentar</Text>
+          </TouchableOpacity>
+        </View>
+      )}
+
       <FlatList
-        data={trades}
+        data={items}
         keyExtractor={(item) => item.id}
         contentContainerStyle={{ gap: 12, paddingVertical: 12 }}
         renderItem={({ item }) => (
           <View style={styles.card}>
             <Text style={styles.cardTitle}>{item.title}</Text>
-            <Text style={styles.description}>{item.description}</Text>
-            <Text style={styles.tokens}>{`~${item.tokens} tokens`}</Text>
+            {item.status && <Text style={styles.badge}>{item.status}</Text>}
+            {item.participants && (
+              <Text style={styles.description}>
+                Participantes: {item.participants.join(", ")}
+              </Text>
+            )}
+            {typeof item.tokens === "number" && (
+              <Text style={styles.tokens}>{`~${item.tokens} tokens`}</Text>
+            )}
           </View>
         )}
+        ListEmptyComponent={
+          !loading && !error ? (
+            <Text style={styles.statusText}>No hay trueques activos aún.</Text>
+          ) : null
+        }
       />
     </View>
   );
@@ -86,5 +101,28 @@ const styles = StyleSheet.create({
   tokens: {
     color: colors.primary,
     fontWeight: "700",
+  },
+  statusBox: {
+    marginTop: 12,
+  },
+  statusText: {
+    color: colors.muted,
+  },
+  retryButton: {
+    marginTop: 8,
+    alignSelf: "flex-start",
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 10,
+    backgroundColor: colors.primary,
+  },
+  retryText: {
+    color: "#FFF",
+    fontWeight: "700",
+  },
+  badge: {
+    color: colors.primary,
+    fontWeight: "700",
+    marginTop: 4,
   },
 });

--- a/trueqia/src/store/auth.store.ts
+++ b/trueqia/src/store/auth.store.ts
@@ -1,3 +1,4 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { create } from "zustand";
 import { apiPost, AuthResponse } from "../config/api";
 
@@ -11,23 +12,57 @@ type User = {
 interface AuthState {
   token: string | null;
   user: User | null;
+  sessionMessage: string | null;
+  hydrated: boolean;
   setAuth: (payload: AuthResponse) => void;
+  restoreSession: () => Promise<void>;
   login: (email: string, password: string) => Promise<void>;
   register: (name: string, email: string, password: string) => Promise<void>;
-  logout: () => void;
+  logout: (message?: string) => Promise<void>;
+  clearSessionMessage: () => void;
+}
+
+const STORAGE_KEY = "trueqia_auth";
+
+async function persistAuth(token: string, user: User) {
+  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify({ token, user }));
+}
+
+async function clearPersistedAuth() {
+  await AsyncStorage.removeItem(STORAGE_KEY);
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
   token: null,
   user: null,
+  sessionMessage: null,
+  hydrated: false,
   setAuth: ({ token, user }) => set({ token, user }),
+  restoreSession: async () => {
+    try {
+      const raw = await AsyncStorage.getItem(STORAGE_KEY);
+      if (!raw) return;
+      const parsed = JSON.parse(raw);
+      if (parsed?.token && parsed?.user) {
+        set({ token: parsed.token, user: parsed.user });
+      }
+    } finally {
+      set({ hydrated: true });
+    }
+  },
   login: async (email, password) => {
     const res = await apiPost<AuthResponse>("/auth/login", { email, password });
-    set({ token: res.token, user: res.user });
+    await persistAuth(res.token, res.user);
+    set({ token: res.token, user: res.user, sessionMessage: null });
   },
   register: async (name, email, password) => {
     const res = await apiPost<AuthResponse>("/auth/register", { name, email, password });
-    set({ token: res.token, user: res.user });
+    await persistAuth(res.token, res.user);
+    set({ token: res.token, user: res.user, sessionMessage: null });
   },
-  logout: () => set({ token: null, user: null }),
+  logout: async (message) => {
+    await clearPersistedAuth();
+    set({ token: null, user: null, sessionMessage: message ?? null });
+  },
+  clearSessionMessage: () => set({ sessionMessage: null }),
 }));

--- a/trueqia/src/store/trades.store.ts
+++ b/trueqia/src/store/trades.store.ts
@@ -1,0 +1,35 @@
+import { create } from "zustand";
+import { apiAuthGet } from "../config/api";
+
+type Trade = {
+  id: string;
+  title: string;
+  status?: string;
+  participants?: string[];
+  tokens?: number;
+};
+
+interface TradesState {
+  items: Trade[];
+  loading: boolean;
+  error: string | null;
+  loadTrades: () => Promise<void>;
+}
+
+export const useTradesStore = create<TradesState>((set) => ({
+  items: [],
+  loading: false,
+  error: null,
+  loadTrades: async () => {
+    try {
+      set({ loading: true, error: null });
+      const res = await apiAuthGet<{ items?: Trade[] }>("/trueqia/trades");
+      set({ items: res.items || [], loading: false });
+    } catch (err: any) {
+      set({
+        error: err?.message || "ERROR_LOADING_TRADES",
+        loading: false,
+      });
+    }
+  },
+}));


### PR DESCRIPTION
## Summary
- Persist and restore sessions with AsyncStorage in TrueQIA and Allwain, handling 401s with automatic logout messaging and gated navigation loaders
- Connect TrueQIA trades/offers/contracts to backend responses with clearer empty/error states and profile/logout polish
- Refresh Allwain offer, scan, and profile flows while aligning backend seeds and auth error responses for consistent demos

## Testing
- Not run (npm install blocked in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f5f30cc6c8326a2e90b0b1da935b5)